### PR TITLE
Fix frontend to match backend API response structure

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -18,7 +18,14 @@ apiClient.interceptors.request.use((config) => {
 });
 
 apiClient.interceptors.response.use(
-  (response) => response,
+  (response) => {
+    // Backend wraps all responses in: { success, data, error, timestamp, request_id }
+    // Unwrap the envelope so callers get the inner data directly.
+    if (response.data && typeof response.data === 'object' && 'success' in response.data) {
+      response.data = response.data.data;
+    }
+    return response;
+  },
   async (error) => {
     if (error.response?.status === 401) {
       sessionStorage.removeItem('access_token');

--- a/src/pages/Agents/AgentList.tsx
+++ b/src/pages/Agents/AgentList.tsx
@@ -4,7 +4,18 @@ import { useQuery } from '@tanstack/react-query';
 import { DataTable } from '@/components/common/DataTable';
 import { StatusBadge } from '@/components/common/StatusBadge';
 import { agentsApi } from '@/api/agents';
-import type { Agent, AgentState } from '@/types';
+import type { AgentState } from '@/types';
+
+interface AgentRow {
+  id: string;
+  ip: string;
+  state: string;
+  attestation_mode: string;
+  last_attestation: string | null;
+  assigned_policy: string;
+  failure_count: number;
+  [key: string]: unknown;
+}
 
 export function AgentList() {
   const navigate = useNavigate();
@@ -24,19 +35,27 @@ export function AgentList() {
     select: (res) => res.data,
   });
 
+  const items: AgentRow[] = Array.isArray(data?.items) ? data.items : Array.isArray(data) ? data : [];
+  const totalPages = data?.total_pages ?? 1;
+
   const columns = [
-    { key: 'uuid', header: 'Agent ID', sortable: true },
-    { key: 'hostname', header: 'Hostname', sortable: true },
-    { key: 'ip_address', header: 'IP Address', sortable: true },
+    { key: 'id', header: 'Agent ID', sortable: true },
+    { key: 'ip', header: 'IP Address', sortable: true },
     {
       key: 'state',
       header: 'State',
       sortable: true,
-      render: (row: Agent) => <StatusBadge label={row.state} />,
+      render: (row: AgentRow) => <StatusBadge label={row.state} />,
     },
-    { key: 'ima_policy', header: 'Policy', sortable: true },
-    { key: 'last_attestation', header: 'Last Attestation', sortable: true },
-    { key: 'consecutive_failures', header: 'Failures', sortable: true },
+    { key: 'attestation_mode', header: 'Mode', sortable: true },
+    { key: 'assigned_policy', header: 'Policy', sortable: true },
+    {
+      key: 'last_attestation',
+      header: 'Last Attestation',
+      sortable: true,
+      render: (row: AgentRow) => <span>{row.last_attestation ?? '--'}</span>,
+    },
+    { key: 'failure_count', header: 'Failures', sortable: true },
   ];
 
   return (
@@ -87,14 +106,14 @@ export function AgentList() {
         </div>
       ) : (
         <>
-          <DataTable<Agent>
+          <DataTable<AgentRow>
             columns={columns}
-            data={Array.isArray(data?.data) ? data.data : Array.isArray(data) ? data : []}
-            keyField="uuid"
-            onRowClick={(row) => navigate(`/agents/${row.uuid}`)}
+            data={items}
+            keyField="id"
+            onRowClick={(row) => navigate(`/agents/${row.id}`)}
             selectable
           />
-          {data && data.total_pages > 1 && (
+          {totalPages > 1 && (
             <div style={{ display: 'flex', justifyContent: 'center', gap: '8px', marginTop: '16px' }}>
               <button
                 onClick={() => setPage((p) => Math.max(1, p - 1))}
@@ -104,11 +123,11 @@ export function AgentList() {
                 Previous
               </button>
               <span style={{ padding: '6px 12px', fontSize: '14px' }}>
-                Page {page} of {data.total_pages}
+                Page {page} of {totalPages}
               </span>
               <button
-                onClick={() => setPage((p) => Math.min(data.total_pages, p + 1))}
-                disabled={page >= data.total_pages}
+                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                disabled={page >= totalPages}
                 style={{ padding: '6px 16px', borderRadius: 'var(--radius-sm)', border: '1px solid var(--color-border)', background: 'var(--color-surface)' }}
               >
                 Next

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -39,7 +39,7 @@ export function Dashboard() {
       <div className="kpi-grid">
         <KpiCard
           title="Total Agents"
-          value={agents?.total ?? '--'}
+          value={agents?.total_items ?? '--'}
           variant="default"
         />
         <KpiCard

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,10 +15,10 @@ export interface User {
 }
 
 export interface PaginatedResponse<T> {
-  data: T[];
-  total: number;
+  items: T[];
   page: number;
-  per_page: number;
+  page_size: number;
+  total_items: number;
   total_pages: number;
 }
 


### PR DESCRIPTION
The backend wraps all responses in an ApiResponse envelope ({ success, data, error, timestamp, request_id }) and uses different field names than the frontend expected (items vs data, total_items vs total, id vs uuid, ip vs ip_address).

- Unwrap ApiResponse envelope automatically in Axios interceptor
- Update PaginatedResponse type to match backend (items, page_size, total_items, total_pages)
- Align AgentList columns with actual backend fields (id, ip, state, attestation_mode, assigned_policy, failure_count)
- Fix Dashboard to use total_items for agent count