### PR TITLE
Add agent state distribution pie chart and fix paginated data access

### DIFF
--- a/src/pages/Agents/AgentList.tsx
+++ b/src/pages/Agents/AgentList.tsx
@@ -35,7 +35,9 @@ export function AgentList() {
     select: (res) => res.data,
   });
 
-  const items: AgentRow[] = Array.isArray(data?.items) ? data.items : Array.isArray(data) ? data : [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const rawItems = (data as any)?.items ?? data;
+  const items: AgentRow[] = Array.isArray(rawItems) ? rawItems : [];
   const totalPages = data?.total_pages ?? 1;
 
   const columns = [

--- a/src/pages/Alerts/Alerts.tsx
+++ b/src/pages/Alerts/Alerts.tsx
@@ -141,7 +141,7 @@ export function Alerts() {
       ) : (
         <DataTable<Alert>
           columns={columns}
-          data={Array.isArray(alerts?.data) ? alerts.data : Array.isArray(alerts) ? alerts : []}
+          data={Array.isArray(alerts?.items) ? alerts.items : Array.isArray(alerts) ? alerts : []}
           keyField="id"
         />
       )}

--- a/src/pages/Attestations/Attestations.tsx
+++ b/src/pages/Attestations/Attestations.tsx
@@ -1,7 +1,16 @@
 import { useQuery } from '@tanstack/react-query';
 import { useOutletContext } from 'react-router-dom';
 import { KpiCard } from '@/components/common/KpiCard';
+import { StatusBadge } from '@/components/common/StatusBadge';
 import { attestationsApi } from '@/api/attestations';
+
+interface FailureEvent {
+  agent_id: string;
+  detail: string;
+  failure_type: string;
+  severity: string;
+  timestamp: string;
+}
 
 export function Attestations() {
   const { timeRange } = useOutletContext<{ timeRange: string }>();
@@ -50,19 +59,23 @@ export function Attestations() {
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '24px' }}>
         <div className="section">
           <h2 className="section__title">Failure Categorization</h2>
-          {failures && failures.length > 0 ? (
+          {Array.isArray(failures) && failures.length > 0 ? (
             <ul style={{ listStyle: 'none', padding: 0 }}>
-              {failures.map((f) => (
-                <li key={f.type} style={{ display: 'flex', justifyContent: 'space-between', padding: '8px 0', borderBottom: '1px solid var(--color-border)' }}>
-                  <span style={{ textTransform: 'capitalize' }}>{f.type.replace(/_/g, ' ')}</span>
-                  <span style={{ fontWeight: 600 }}>{f.count} ({f.percentage.toFixed(1)}%)</span>
+              {(failures as unknown as FailureEvent[]).map((f, i) => (
+                <li key={f.agent_id + i} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '8px 0', borderBottom: '1px solid var(--color-border)' }}>
+                  <div>
+                    <div style={{ fontWeight: 500 }}>{(f.failure_type ?? '').replace(/_/g, ' ')}</div>
+                    <div style={{ fontSize: '12px', color: 'var(--color-text-secondary)' }}>{f.detail ?? ''}</div>
+                    <div style={{ fontSize: '11px', color: 'var(--color-text-secondary)', fontFamily: 'monospace' }}>{f.agent_id}</div>
+                  </div>
+                  <StatusBadge label={f.severity} />
                 </li>
               ))}
             </ul>
           ) : (
             <div className="placeholder">
               <div className="placeholder__icon">&#x1F4CA;</div>
-              <div className="placeholder__text">Failure breakdown donut chart</div>
+              <div className="placeholder__text">No failures recorded</div>
             </div>
           )}
         </div>

--- a/src/pages/AuditLog/AuditLog.tsx
+++ b/src/pages/AuditLog/AuditLog.tsx
@@ -112,7 +112,7 @@ export function AuditLog() {
       ) : (
         <DataTable<AuditLogEntry>
           columns={columns}
-          data={Array.isArray(data?.data) ? data.data : Array.isArray(data) ? data : []}
+          data={Array.isArray(data?.items) ? data.items : Array.isArray(data) ? data : []}
           keyField="id"
         />
       )}

--- a/src/pages/Certificates/Certificates.tsx
+++ b/src/pages/Certificates/Certificates.tsx
@@ -87,7 +87,7 @@ export function Certificates() {
       ) : (
         <DataTable<Certificate>
           columns={columns}
-          data={Array.isArray(certs?.data) ? certs.data : Array.isArray(certs) ? certs : []}
+          data={Array.isArray(certs?.items) ? certs.items : Array.isArray(certs) ? certs : []}
           keyField="id"
           selectable
         />

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -1,17 +1,30 @@
+import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 import { KpiCard } from '@/components/common/KpiCard';
-import { StatusBadge } from '@/components/common/StatusBadge';
 import { attestationsApi } from '@/api/attestations';
 import { agentsApi } from '@/api/agents';
 import { alertsApi } from '@/api/alerts';
 import { useOutletContext } from 'react-router-dom';
 
+const STATE_COLORS: Record<string, string> = {
+  GET_QUOTE: '#34a853',
+  PROVIDE_V: '#4285f4',
+  REGISTERED: '#a0c4ff',
+  FAILED: '#ea4335',
+  RETRY: '#f9ab00',
+  TERMINATED: '#9e9e9e',
+  INVALID_QUOTE: '#d93025',
+  TENANT_FAILED: '#c62828',
+  UNKNOWN: '#bdbdbd',
+};
+
 export function Dashboard() {
   const { timeRange } = useOutletContext<{ timeRange: string }>();
 
   const { data: agents } = useQuery({
-    queryKey: ['agents', 'list'],
-    queryFn: () => agentsApi.list({ per_page: 1 }),
+    queryKey: ['agents', 'dashboard'],
+    queryFn: () => agentsApi.list({ per_page: 100 }),
     select: (res) => res.data,
   });
 
@@ -27,6 +40,17 @@ export function Dashboard() {
     select: (res) => res.data,
   });
 
+  const agentItems = Array.isArray(agents?.items) ? agents.items : Array.isArray(agents) ? agents : [];
+
+  const stateDistribution = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const agent of agentItems) {
+      const state = agent.state ?? 'UNKNOWN';
+      counts[state] = (counts[state] ?? 0) + 1;
+    }
+    return Object.entries(counts).map(([name, value]) => ({ name, value }));
+  }, [agentItems]);
+
   return (
     <div>
       <div className="page-header">
@@ -39,7 +63,7 @@ export function Dashboard() {
       <div className="kpi-grid">
         <KpiCard
           title="Total Agents"
-          value={agents?.total_items ?? '--'}
+          value={agents?.total_items ?? (agentItems.length || '--')}
           variant="default"
         />
         <KpiCard
@@ -94,20 +118,39 @@ export function Dashboard() {
 
       <div className="section">
         <h2 className="section__title">Agent State Distribution</h2>
-        <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
-          <StatusBadge label="GET_QUOTE" />
-          <StatusBadge label="FAILED" />
-          <StatusBadge label="RETRY" />
-          <StatusBadge label="REGISTERED" />
-          <StatusBadge label="TERMINATED" />
-        </div>
-        <div className="placeholder" style={{ paddingTop: '30px' }}>
-          <div className="placeholder__icon">&#x25EF;</div>
-          <div className="placeholder__text">State distribution pie chart</div>
-          <div className="placeholder__subtext">
-            Agent count by state with color-coded segments.
+        {stateDistribution.length > 0 ? (
+          <ResponsiveContainer width="100%" height={300}>
+            <PieChart>
+              <Pie
+                data={stateDistribution}
+                cx="50%"
+                cy="50%"
+                outerRadius={100}
+                innerRadius={50}
+                dataKey="value"
+                nameKey="name"
+                label={({ name, value }) => `${name} (${value})`}
+                labelLine
+              >
+                {stateDistribution.map((entry) => (
+                  <Cell
+                    key={entry.name}
+                    fill={STATE_COLORS[entry.name] ?? STATE_COLORS.UNKNOWN}
+                  />
+                ))}
+              </Pie>
+              <Tooltip
+                formatter={(value: number, name: string) => [`${value} agent${value !== 1 ? 's' : ''}`, name]}
+              />
+              <Legend />
+            </PieChart>
+          </ResponsiveContainer>
+        ) : (
+          <div className="placeholder">
+            <div className="placeholder__icon">&#x25EF;</div>
+            <div className="placeholder__text">No agents found</div>
           </div>
-        </div>
+        )}
       </div>
     </div>
   );

--- a/src/pages/Policies/Policies.tsx
+++ b/src/pages/Policies/Policies.tsx
@@ -96,7 +96,7 @@ export function Policies() {
       ) : (
         <DataTable<Policy>
           columns={columns}
-          data={Array.isArray(data?.data) ? data.data : Array.isArray(data) ? data : []}
+          data={Array.isArray(data?.items) ? data.items : Array.isArray(data) ? data : []}
           keyField="id"
         />
       )}


### PR DESCRIPTION
Implement the Agent State Distribution donut chart on the Dashboard using Recharts, showing agent counts by state (GET_QUOTE, FAILED, PROVIDE_V, etc.) with color-coded segments.

Also fixes:
- Update all pages to use `items` field from PaginatedResponse (was incorrectly using `data`)
- Fix Attestations page to match backend failure response shape (failure_type, detail, severity instead of type, count, percentage)
- Fix AgentList item extraction for backend response