### PR TITLE
Add CI pipeline with linting, tests and build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npx tsc -b
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npx vitest --run
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: [typecheck, lint, test]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,31 @@
+import js from '@eslint/js';
+import tsPlugin from '@typescript-eslint/eslint-plugin';
+import tsParser from '@typescript-eslint/parser';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+
+export default [
+  { ignores: ['dist/**', 'node_modules/**'] },
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+        ecmaFeatures: { jsx: true },
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh,
+    },
+    rules: {
+      ...tsPlugin.configs.recommended.rules,
+      ...reactHooks.configs.recommended.rules,
+      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "lint": "eslint src --max-warnings 0",
     "test": "vitest"
   },
   "dependencies": {

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -40,7 +40,10 @@ export function Dashboard() {
     select: (res) => res.data,
   });
 
-  const agentItems = Array.isArray(agents?.items) ? agents.items : Array.isArray(agents) ? agents : [];
+  const agentItems = useMemo(
+    () => Array.isArray(agents?.items) ? agents.items : Array.isArray(agents) ? agents : [],
+    [agents]
+  );
 
   const stateDistribution = useMemo(() => {
     const counts: Record<string, number> = {};

--- a/src/test/App.test.tsx
+++ b/src/test/App.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Sidebar } from '@/components/Layout/Sidebar';
+
+function renderWithProviders(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('Sidebar', () => {
+  it('renders all navigation links', () => {
+    renderWithProviders(<Sidebar />);
+
+    expect(screen.getByText('Dashboard')).toBeDefined();
+    expect(screen.getByText('Agents')).toBeDefined();
+    expect(screen.getByText('Attestations')).toBeDefined();
+    expect(screen.getByText('Policies')).toBeDefined();
+    expect(screen.getByText('Certificates')).toBeDefined();
+    expect(screen.getByText('Alerts')).toBeDefined();
+    expect(screen.getByText('Performance')).toBeDefined();
+    expect(screen.getByText('Audit Log')).toBeDefined();
+    expect(screen.getByText('Integrations')).toBeDefined();
+    expect(screen.getByText('Settings')).toBeDefined();
+  });
+
+  it('renders the Keylime Monitor branding', () => {
+    renderWithProviders(<Sidebar />);
+
+    expect(screen.getByText('Keylime Monitor')).toBeDefined();
+  });
+});


### PR DESCRIPTION
Set up GitHub Actions CI workflow that runs on push/PR to main with four jobs: TypeScript type checking, ESLint linting, Vitest unit tests, and production build (gated on the first three passing).

- Add ESLint flat config with TypeScript and React hooks rules
- Add Sidebar smoke test verifying all 10 navigation links render
- Update lint script for flat config compatibility
- Fix Dashboard useMemo dependency warning