### PR TITLE
Add local pre-commit check script

### DIFF
--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+passed=0
+failed=0
+
+run_step() {
+  local name="$1"
+  shift
+  printf "  %-20s" "$name"
+  if "$@" &> /dev/null; then
+    echo "OK"
+    ((passed++))
+  else
+    echo "FAIL"
+    ((failed++))
+  fi
+}
+
+echo "Running CI checks..."
+echo ""
+
+run_step "Type Check" npx tsc -b
+run_step "Lint" npm run --silent lint
+run_step "Test" npx vitest --run
+run_step "Build" npm run --silent build
+
+echo ""
+echo "Results: $passed passed, $failed failed"
+
+if [ "$failed" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
Provides a quick local script that mirrors CI checks (type check, lint, test, build) so developers can verify readiness before committing.