### PR TITLE
Add pre-commit git hook, document setup in README

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+exec "$REPO_ROOT/scripts/pre-commit.sh"

--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ src/
   types/        - TypeScript type definitions
 ```
 
+## Git Hooks
+
+A pre-commit hook is provided to run CI checks (type check, lint, test, build) before each commit. To enable it:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+You can also run the checks manually at any time:
+
+```bash
+./scripts/pre-commit.sh
+```
+
 ## License
 
 Apache-2.0


### PR DESCRIPTION
Adds a .githooks/pre-commit hook that delegates to scripts/pre-commit.sh and documents how to enable it via git config core.hooksPath.