### PR TITLE
Fix PCR values tab to match backend API

### DIFF
--- a/src/api/agents.ts
+++ b/src/api/agents.ts
@@ -24,7 +24,7 @@ export const agentsApi = {
   },
 
   pcrValues(agentId: string) {
-    return apiClient.get<AgentPcrValues>(`/agents/${agentId}/pcr-values`);
+    return apiClient.get<AgentPcrValues>(`/agents/${agentId}/pcr`);
   },
 
   imaLog(agentId: string, params?: { search?: string }) {

--- a/src/pages/Agents/AgentDetail.tsx
+++ b/src/pages/Agents/AgentDetail.tsx
@@ -150,28 +150,29 @@ function PcrTab({ agentId }: { agentId: string }) {
     <div>
       <h3 className="section__title">PCR Values</h3>
       {data ? (
-        <table className="data-table" style={{ border: '1px solid var(--color-border)', borderRadius: 'var(--radius-sm)' }}>
-          <thead>
-            <tr>
-              <th className="data-table__th">PCR Index</th>
-              <th className="data-table__th">Current Value</th>
-              <th className="data-table__th">Expected Value</th>
-              <th className="data-table__th">Match</th>
-            </tr>
-          </thead>
-          <tbody>
-            {Object.entries(data.values).map(([idx, val]) => (
-              <tr key={idx}>
-                <td className="data-table__td">{idx}</td>
-                <td className="data-table__td" style={{ fontFamily: 'monospace', fontSize: '12px' }}>{val}</td>
-                <td className="data-table__td" style={{ fontFamily: 'monospace', fontSize: '12px' }}>{data.expected[idx] ?? '--'}</td>
-                <td className="data-table__td">
-                  <StatusBadge label={val === data.expected[idx] ? 'PASS' : 'FAIL'} />
-                </td>
+        <>
+          <p style={{ fontSize: '14px', color: 'var(--color-text-secondary)', marginBottom: '12px' }}>
+            Hash algorithm: <strong>{data.hash_alg}</strong>
+          </p>
+          <table className="data-table" style={{ border: '1px solid var(--color-border)', borderRadius: 'var(--radius-sm)' }}>
+            <thead>
+              <tr>
+                <th className="data-table__th">PCR Index</th>
+                <th className="data-table__th">Value</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {Object.entries(data.pcrs)
+                .sort(([a], [b]) => Number(a) - Number(b))
+                .map(([idx, val]) => (
+                  <tr key={idx}>
+                    <td className="data-table__td">{idx}</td>
+                    <td className="data-table__td" style={{ fontFamily: 'monospace', fontSize: '12px' }}>{val}</td>
+                  </tr>
+                ))}
+            </tbody>
+          </table>
+        </>
       ) : (
         <div className="placeholder">
           <div className="placeholder__text">Loading PCR values...</div>

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -44,9 +44,8 @@ export interface AgentListParams {
 }
 
 export interface AgentPcrValues {
-  bank: string;
-  values: Record<string, string>;
-  expected: Record<string, string>;
+  hash_alg: string;
+  pcrs: Record<string, string>;
 }
 
 export interface ImaLogEntry {


### PR DESCRIPTION
Correct the endpoint URL from /pcr-values to /pcr and align the AgentPcrValues type with the backend response (hash_alg + pcrs map). PCR entries are now sorted by index.