### PR TITLE
Support push-mode states, set Mode before State

### DIFF
--- a/src/components/common/StatusBadge.tsx
+++ b/src/components/common/StatusBadge.tsx
@@ -27,6 +27,8 @@ const VARIANT_MAP: Record<string, BadgeVariant> = {
   critical: 'danger',
   warning: 'warning',
   info: 'info',
+  // Push-mode agent states
+  pending: 'warning',
   // Generic
   pass: 'success',
   fail: 'danger',

--- a/src/pages/Agents/AgentList.tsx
+++ b/src/pages/Agents/AgentList.tsx
@@ -52,13 +52,13 @@ export function AgentList() {
       ),
     },
     { key: 'ip', header: 'IP Address', sortable: true },
+    { key: 'attestation_mode', header: 'Mode', sortable: true },
     {
       key: 'state',
       header: 'State',
       sortable: true,
       render: (row: AgentRow) => <StatusBadge label={row.state} />,
     },
-    { key: 'attestation_mode', header: 'Mode', sortable: true },
     { key: 'assigned_policy', header: 'Policy', sortable: true },
     {
       key: 'last_attestation',

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -8,6 +8,7 @@ import { alertsApi } from '@/api/alerts';
 import { useOutletContext } from 'react-router-dom';
 
 const STATE_COLORS: Record<string, string> = {
+  // Pull-mode states
   GET_QUOTE: '#34a853',
   PROVIDE_V: '#4285f4',
   REGISTERED: '#a0c4ff',
@@ -16,6 +17,10 @@ const STATE_COLORS: Record<string, string> = {
   TERMINATED: '#9e9e9e',
   INVALID_QUOTE: '#d93025',
   TENANT_FAILED: '#c62828',
+  // Push-mode states
+  PASS: '#34a853',
+  FAIL: '#ea4335',
+  PENDING: '#f9ab00',
   UNKNOWN: '#bdbdbd',
 };
 


### PR DESCRIPTION
Move Mode column before State in the agent list, add push-mode state colors (PASS/FAIL/PENDING) to the dashboard pie chart, and add PENDING variant to StatusBadge.