### PR TITLE
Wire up global search and add interactive state

### DIFF
--- a/src/api/agents.ts
+++ b/src/api/agents.ts
@@ -11,6 +11,10 @@ export const agentsApi = {
     return apiClient.get<Agent>(`/agents/${agentId}`);
   },
 
+  search(q: string) {
+    return apiClient.get<Agent[]>('/agents/search', { params: { q } });
+  },
+
   action(agentId: string, action: string) {
     return apiClient.post(`/agents/${agentId}/action`, { action });
   },

--- a/src/components/Layout/TopBar.tsx
+++ b/src/components/Layout/TopBar.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { TIME_RANGES } from '@/types';
 import { useAuth } from '@/hooks/useAuth';
 
@@ -9,7 +10,17 @@ interface TopBarProps {
 
 export function TopBar({ selectedTimeRange, onTimeRangeChange }: TopBarProps) {
   const [search, setSearch] = useState('');
+  const navigate = useNavigate();
   const { user } = useAuth();
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    const q = search.trim();
+    if (q) {
+      navigate(`/agents?q=${encodeURIComponent(q)}`);
+      setSearch('');
+    }
+  };
 
   const initials = user?.name
     ? user.name
@@ -22,7 +33,7 @@ export function TopBar({ selectedTimeRange, onTimeRangeChange }: TopBarProps) {
   return (
     <header className="layout__topbar">
       <div className="topbar">
-        <div className="topbar__search">
+        <form className="topbar__search" onSubmit={handleSearch}>
           <span className="topbar__search-icon" aria-hidden="true">
             &#x1F50D;
           </span>
@@ -33,7 +44,7 @@ export function TopBar({ selectedTimeRange, onTimeRangeChange }: TopBarProps) {
             onChange={(e) => setSearch(e.target.value)}
             aria-label="Search agents"
           />
-        </div>
+        </form>
 
         <div className="topbar__spacer" />
 

--- a/src/pages/Agents/AgentList.tsx
+++ b/src/pages/Agents/AgentList.tsx
@@ -1,10 +1,11 @@
-import { useState } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { useState, useEffect } from 'react';
+import { useNavigate, Link, useSearchParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { DataTable } from '@/components/common/DataTable';
 import { StatusBadge } from '@/components/common/StatusBadge';
 import { agentsApi } from '@/api/agents';
-import type { AgentState } from '@/types';
+import type { AgentListParams } from '@/types';
+
 
 interface AgentRow {
   id: string;
@@ -19,26 +20,43 @@ interface AgentRow {
 
 export function AgentList() {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [page, setPage] = useState(1);
-  const [stateFilter, setStateFilter] = useState<AgentState | ''>('');
-  const [search, setSearch] = useState('');
+  const [stateFilter, setStateFilter] = useState<string>(searchParams.get('state') ?? '');
+  const [search, setSearch] = useState(searchParams.get('q') ?? '');
+
+  // Sync search and state filter when URL query params change
+  useEffect(() => {
+    const q = searchParams.get('q') ?? '';
+    const state = searchParams.get('state') ?? '';
+    setSearch(q);
+    setStateFilter(state);
+    setPage(1);
+  }, [searchParams]);
+
+  const isSearchMode = search.trim().length > 0;
 
   const { data, isLoading } = useQuery({
     queryKey: ['agents', page, stateFilter, search],
-    queryFn: () =>
-      agentsApi.list({
+    queryFn: async () => {
+      if (isSearchMode) {
+        const res = await agentsApi.search(search.trim());
+        return res.data;
+      }
+      const res = await agentsApi.list({
         page,
         per_page: 25,
-        state: stateFilter || undefined,
-        search: search || undefined,
-      }),
-    select: (res) => res.data,
+        state: (stateFilter || undefined) as AgentListParams['state'],
+      });
+      return res.data;
+    },
   });
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const rawItems = (data as any)?.items ?? data;
   const items: AgentRow[] = Array.isArray(rawItems) ? rawItems : [];
-  const totalPages = data?.total_pages ?? 1;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const totalPages = (data as any)?.total_pages ?? 1;
 
   const columns = [
     {
@@ -81,7 +99,15 @@ export function AgentList() {
           type="search"
           placeholder="Search by UUID, hostname, or IP..."
           value={search}
-          onChange={(e) => { setSearch(e.target.value); setPage(1); }}
+          onChange={(e) => {
+            setSearch(e.target.value);
+            setPage(1);
+            if (e.target.value) {
+              setSearchParams({ q: e.target.value });
+            } else {
+              setSearchParams({});
+            }
+          }}
           style={{
             flex: 1,
             padding: '8px 12px',
@@ -93,7 +119,18 @@ export function AgentList() {
         />
         <select
           value={stateFilter}
-          onChange={(e) => { setStateFilter(e.target.value as AgentState | ''); setPage(1); }}
+          onChange={(e) => {
+            const val = e.target.value;
+            setStateFilter(val);
+            setPage(1);
+            const next = new URLSearchParams(searchParams);
+            if (val) {
+              next.set('state', val);
+            } else {
+              next.delete('state');
+            }
+            setSearchParams(next);
+          }}
           style={{
             padding: '8px 12px',
             border: '1px solid var(--color-border)',
@@ -103,11 +140,21 @@ export function AgentList() {
           aria-label="Filter by state"
         >
           <option value="">All states</option>
-          <option value="get_quote">Get Quote</option>
-          <option value="failed">Failed</option>
-          <option value="retry">Retry</option>
-          <option value="registered">Registered</option>
-          <option value="terminated">Terminated</option>
+          <optgroup label="Pull Mode">
+            <option value="GET_QUOTE">Get Quote</option>
+            <option value="PROVIDE_V">Provide V</option>
+            <option value="REGISTERED">Registered</option>
+            <option value="FAILED">Failed</option>
+            <option value="RETRY">Retry</option>
+            <option value="TERMINATED">Terminated</option>
+            <option value="INVALID_QUOTE">Invalid Quote</option>
+            <option value="TENANT_FAILED">Tenant Failed</option>
+          </optgroup>
+          <optgroup label="Push Mode">
+            <option value="PASS">Pass</option>
+            <option value="FAIL">Fail</option>
+            <option value="PENDING">Pending</option>
+          </optgroup>
         </select>
       </div>
 

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -5,7 +5,7 @@ import { KpiCard } from '@/components/common/KpiCard';
 import { attestationsApi } from '@/api/attestations';
 import { agentsApi } from '@/api/agents';
 import { alertsApi } from '@/api/alerts';
-import { useOutletContext } from 'react-router-dom';
+import { useOutletContext, useNavigate } from 'react-router-dom';
 
 const STATE_COLORS: Record<string, string> = {
   // Pull-mode states
@@ -24,8 +24,16 @@ const STATE_COLORS: Record<string, string> = {
   UNKNOWN: '#bdbdbd',
 };
 
+interface StateEntry {
+  name: string;
+  state: string;
+  mode: string;
+  value: number;
+}
+
 export function Dashboard() {
   const { timeRange } = useOutletContext<{ timeRange: string }>();
+  const navigate = useNavigate();
 
   const { data: agents } = useQuery({
     queryKey: ['agents', 'dashboard'],
@@ -50,13 +58,22 @@ export function Dashboard() {
     [agents]
   );
 
-  const stateDistribution = useMemo(() => {
-    const counts: Record<string, number> = {};
+  const stateDistribution: StateEntry[] = useMemo(() => {
+    const map = new Map<string, { state: string; mode: string; count: number }>();
     for (const agent of agentItems) {
       const state = agent.state ?? 'UNKNOWN';
-      counts[state] = (counts[state] ?? 0) + 1;
+      const mode = agent.attestation_mode ?? 'Unknown';
+      if (!map.has(state)) {
+        map.set(state, { state, mode, count: 0 });
+      }
+      map.get(state)!.count += 1;
     }
-    return Object.entries(counts).map(([name, value]) => ({ name, value }));
+    return Array.from(map.values()).map(({ state, mode, count }) => ({
+      name: `${state} (${mode})`,
+      state,
+      mode,
+      value: count,
+    }));
   }, [agentItems]);
 
   return (
@@ -116,18 +133,33 @@ export function Dashboard() {
                 nameKey="name"
                 label={({ name, value }) => `${name} (${value})`}
                 labelLine
+                style={{ cursor: 'pointer' }}
+                onClick={(_data, index) => {
+                  const entry = stateDistribution[index];
+                  if (entry) {
+                    navigate(`/agents?state=${encodeURIComponent(entry.state)}`);
+                  }
+                }}
               >
                 {stateDistribution.map((entry) => (
                   <Cell
                     key={entry.name}
-                    fill={STATE_COLORS[entry.name] ?? STATE_COLORS.UNKNOWN}
+                    fill={STATE_COLORS[entry.state] ?? STATE_COLORS.UNKNOWN}
                   />
                 ))}
               </Pie>
               <Tooltip
                 formatter={(value: number, name: string) => [`${value} agent${value !== 1 ? 's' : ''}`, name]}
               />
-              <Legend />
+              <Legend
+                onClick={(e) => {
+                  const entry = stateDistribution.find((s) => s.name === e.value);
+                  if (entry) {
+                    navigate(`/agents?state=${encodeURIComponent(entry.state)}`);
+                  }
+                }}
+                formatter={(value) => <span style={{ cursor: 'pointer' }}>{value}</span>}
+              />
             </PieChart>
           </ResponsiveContainer>
         ) : (


### PR DESCRIPTION
TopBar search now navigates to /agents?q=<term> on Enter, using the backend search endpoint. The dashboard pie chart labels include the attestation mode (Pull/Push) and clicking a slice or legend entry navigates to the agents list filtered by that state. The agent list state dropdown is grouped by mode and syncs with URL parameters.