### PR TITLE
Add resizable sidebar, split IMA/MB policy columns

### DIFF
--- a/src/components/Layout/Layout.css
+++ b/src/components/Layout/Layout.css
@@ -16,6 +16,23 @@
   z-index: 10;
 }
 
+.layout__resize-handle {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: var(--sidebar-width);
+  width: 4px;
+  cursor: col-resize;
+  z-index: 11;
+  background: transparent;
+  transition: background 0.15s;
+}
+
+.layout__resize-handle:hover,
+.layout__resize-handle:active {
+  background: var(--color-primary);
+}
+
 .layout__main {
   flex: 1;
   margin-left: var(--sidebar-width);

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,15 +1,51 @@
-import { useState } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
 import { Sidebar } from './Sidebar';
 import { TopBar } from './TopBar';
 import './Layout.css';
 
+const MIN_SIDEBAR = 180;
+const MAX_SIDEBAR = 400;
+const DEFAULT_SIDEBAR = 240;
+
 export function Layout() {
   const [timeRange, setTimeRange] = useState('24h');
+  const [sidebarWidth, setSidebarWidth] = useState(DEFAULT_SIDEBAR);
+  const dragging = useRef(false);
+
+  const onMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    dragging.current = true;
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+  }, []);
+
+  useEffect(() => {
+    const onMouseMove = (e: MouseEvent) => {
+      if (!dragging.current) return;
+      const newWidth = Math.min(MAX_SIDEBAR, Math.max(MIN_SIDEBAR, e.clientX));
+      setSidebarWidth(newWidth);
+    };
+    const onMouseUp = () => {
+      if (!dragging.current) return;
+      dragging.current = false;
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+    return () => {
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+    };
+  }, []);
+
+  const style = { '--sidebar-width': `${sidebarWidth}px` } as React.CSSProperties;
 
   return (
-    <div className="layout">
+    <div className="layout" style={style}>
       <Sidebar />
+      <div className="layout__resize-handle" onMouseDown={onMouseDown} />
       <div className="layout__main">
         <TopBar selectedTimeRange={timeRange} onTimeRangeChange={setTimeRange} />
         <main className="layout__content">

--- a/src/index.css
+++ b/src/index.css
@@ -12,7 +12,6 @@
   --color-text: #1f2937;
   --color-text-secondary: #6b7280;
 
-  --sidebar-width: 240px;
   --topbar-height: 56px;
 
   --radius-sm: 4px;

--- a/src/pages/Agents/AgentList.tsx
+++ b/src/pages/Agents/AgentList.tsx
@@ -14,6 +14,7 @@ interface AgentRow {
   attestation_mode: string;
   last_attestation: string | null;
   assigned_policy: string;
+  mb_policy: string | null;
   failure_count: number;
   [key: string]: unknown;
 }
@@ -77,7 +78,13 @@ export function AgentList() {
       sortable: true,
       render: (row: AgentRow) => <StatusBadge label={row.state} />,
     },
-    { key: 'assigned_policy', header: 'Policy', sortable: true },
+    { key: 'assigned_policy', header: 'IMA Policy', sortable: true },
+    {
+      key: 'mb_policy',
+      header: 'MB Policy',
+      sortable: true,
+      render: (row: AgentRow) => <span>{row.mb_policy ?? '--'}</span>,
+    },
     {
       key: 'last_attestation',
       header: 'Last Attestation',


### PR DESCRIPTION
Make the sidebar width adjustable by dragging the border between the sidebar and the main content (180px-400px range). Also split the agent list Policy column into separate IMA Policy and MB Policy columns to match the independent policy model in Keylime.