### PR TITLE
Fix policy type column to match backend kind field

### DIFF
--- a/src/pages/Policies/Policies.tsx
+++ b/src/pages/Policies/Policies.tsx
@@ -5,6 +5,11 @@ import { StatusBadge } from '@/components/common/StatusBadge';
 import { policiesApi } from '@/api/policies';
 import type { Policy } from '@/types';
 
+const KIND_LABELS: Record<string, string> = {
+  ima: 'IMA',
+  measured_boot: 'Measured Boot',
+};
+
 export function Policies() {
   const [search, setSearch] = useState('');
 
@@ -17,11 +22,11 @@ export function Policies() {
   const columns = [
     { key: 'name', header: 'Name', sortable: true },
     {
-      key: 'type',
+      key: 'kind',
       header: 'Type',
       sortable: true,
       render: (row: Policy) => (
-        <StatusBadge label={row.type?.toUpperCase() ?? '--'} variant="info" />
+        <StatusBadge label={KIND_LABELS[row.kind] ?? row.kind ?? '--'} variant="info" />
       ),
     },
     { key: 'assigned_agents', header: 'Agents', sortable: true },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
 export type { Agent, AgentState, AgentListParams, AgentPcrValues, ImaLogEntry, BootLogEntry } from './agent';
 export type { Attestation, AttestationSummary, AttestationTimelinePoint, FailureCategoryCount, AttestationIncident, FailureType } from './attestation';
-export type { Policy, PolicyVersion, PolicyImpactResult, PolicyType, ApprovalState } from './policy';
+export type { Policy, PolicyVersion, PolicyImpactResult, PolicyKind, ApprovalState } from './policy';
 export type { Certificate, CertificateExpirySummary, CertificateType, ExpiryCategory } from './certificate';
 export type { Alert, AlertSummary, AlertSeverity, AlertState, AlertType } from './alert';
 export type { AuditLogEntry, HashChainStatus, AuditSeverity, AuditAction } from './audit';

--- a/src/types/policy.ts
+++ b/src/types/policy.ts
@@ -1,4 +1,4 @@
-export type PolicyType = 'ima' | 'mb';
+export type PolicyKind = 'ima' | 'measured_boot';
 
 export type ApprovalState =
   | 'draft'
@@ -20,7 +20,7 @@ export interface PolicyVersion {
 export interface Policy {
   id: string;
   name: string;
-  type: PolicyType;
+  kind: PolicyKind;
   content: string;
   checksum: string;
   hash_algorithm: HashAlgorithm;


### PR DESCRIPTION
The frontend read `type` but the backend sends `kind` with values `ima` and `measured_boot`. Align the Policy type definition and render human-readable labels (IMA, Measured Boot) in the table.