### PR TITLE
Redistribute dashboard pie charts

### DIFF
--- a/src/components/common/common.css
+++ b/src/components/common/common.css
@@ -177,6 +177,25 @@
   margin-bottom: 24px;
 }
 
+/* Charts row — side by side on wide screens, stacked on narrow */
+.charts-row {
+  display: flex;
+  gap: 24px;
+  margin-bottom: 24px;
+}
+
+.charts-row > .section {
+  flex: 1;
+  min-width: 0;
+  margin-bottom: 0;
+}
+
+@media (max-width: 900px) {
+  .charts-row {
+    flex-direction: column;
+  }
+}
+
 /* Section */
 .section {
   background: var(--color-surface);

--- a/src/pages/Alerts/Alerts.tsx
+++ b/src/pages/Alerts/Alerts.tsx
@@ -1,50 +1,14 @@
 import { useState, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 import { KpiCard } from '@/components/common/KpiCard';
 import { DataTable } from '@/components/common/DataTable';
 import { StatusBadge } from '@/components/common/StatusBadge';
 import { alertsApi } from '@/api/alerts';
 import type { Alert } from '@/types';
 
-type ChartDimension = 'severity' | 'type' | 'state';
-
-const SEVERITY_COLORS: Record<string, string> = {
-  critical: '#ea4335',
-  warning: '#f9ab00',
-  info: '#1a73e8',
-};
-
-const STATE_COLORS: Record<string, string> = {
-  new: '#ea4335',
-  acknowledged: '#f9ab00',
-  under_investigation: '#4285f4',
-  resolved: '#34a853',
-  dismissed: '#9e9e9e',
-};
-
-const TYPE_COLORS: Record<string, string> = {
-  attestation_failure: '#ea4335',
-  cert_expiry: '#f9ab00',
-  policy_violation: '#e8710a',
-  pcr_change: '#9334e6',
-  service_down: '#d93025',
-  rate_limit: '#4285f4',
-  clock_skew: '#00897b',
-};
-
-const COLOR_MAPS: Record<ChartDimension, Record<string, string>> = {
-  severity: SEVERITY_COLORS,
-  type: TYPE_COLORS,
-  state: STATE_COLORS,
-};
-
-const FALLBACK_COLOR = '#bdbdbd';
-
 export function Alerts() {
   const [severityFilter, setSeverityFilter] = useState('');
   const [stateFilter, setStateFilter] = useState('');
-  const [chartDimension, setChartDimension] = useState<ChartDimension>('severity');
 
   const { data: summary } = useQuery({
     queryKey: ['alerts', 'summary'],
@@ -66,15 +30,6 @@ export function Alerts() {
     () => Array.isArray(alerts?.items) ? alerts.items : Array.isArray(alerts) ? alerts : [],
     [alerts]
   );
-
-  const chartData = useMemo(() => {
-    const counts = new Map<string, number>();
-    for (const alert of alertItems) {
-      const key = alert[chartDimension] ?? 'unknown';
-      counts.set(key, (counts.get(key) ?? 0) + 1);
-    }
-    return Array.from(counts.entries()).map(([name, value]) => ({ name, value }));
-  }, [alertItems, chartDimension]);
 
   const columns = [
     {
@@ -232,113 +187,6 @@ export function Alerts() {
           keyField="id"
         />
       )}
-
-      <div className="section">
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
-          <h2 className="section__title" style={{ margin: 0 }}>Alert Distribution</h2>
-          <div role="group" aria-label="Chart dimension" style={{ display: 'flex', gap: '4px' }}>
-            {(['severity', 'type', 'state'] as ChartDimension[]).map((dim) => (
-              <button
-                key={dim}
-                onClick={() => setChartDimension(dim)}
-                style={{
-                  padding: '6px 14px',
-                  fontSize: '13px',
-                  fontWeight: chartDimension === dim ? 600 : 400,
-                  border: '1px solid var(--color-border)',
-                  borderRadius: 'var(--radius-sm)',
-                  background: chartDimension === dim ? 'var(--color-primary)' : 'var(--color-surface)',
-                  color: chartDimension === dim ? '#fff' : 'inherit',
-                  cursor: 'pointer',
-                  textTransform: 'capitalize',
-                }}
-              >
-                {dim}
-              </button>
-            ))}
-          </div>
-        </div>
-        {chartData.length > 0 ? (
-          <ResponsiveContainer width="100%" height={280}>
-            <PieChart>
-              <Pie
-                data={chartData}
-                cx="50%"
-                cy="50%"
-                outerRadius={90}
-                innerRadius={45}
-                dataKey="value"
-                nameKey="name"
-                label={({ cx, cy, midAngle, outerRadius, name, value }: {
-                  cx: number; cy: number; midAngle: number; outerRadius: number;
-                  name: string; value: number;
-                }) => {
-                  const RADIAN = Math.PI / 180;
-                  const radius = outerRadius + 18;
-                  const x = cx + radius * Math.cos(-midAngle * RADIAN);
-                  const y = cy + radius * Math.sin(-midAngle * RADIAN);
-                  const colors = COLOR_MAPS[chartDimension];
-                  return (
-                    <text
-                      x={x} y={y}
-                      fill={colors[name] ?? FALLBACK_COLOR}
-                      textAnchor={x > cx ? 'start' : 'end'}
-                      dominantBaseline="central"
-                      fontSize={12}
-                    >
-                      {`${name.replace(/_/g, ' ')} (${value})`}
-                    </text>
-                  );
-                }}
-                labelLine
-                style={{ cursor: 'pointer' }}
-                onClick={(_data, index) => {
-                  const entry = chartData[index];
-                  if (!entry) return;
-                  if (chartDimension === 'severity') {
-                    setSeverityFilter(entry.name); setStateFilter('');
-                  } else if (chartDimension === 'state') {
-                    setStateFilter(entry.name); setSeverityFilter('');
-                  }
-                }}
-              >
-                {chartData.map((entry) => (
-                  <Cell
-                    key={entry.name}
-                    fill={COLOR_MAPS[chartDimension][entry.name] ?? FALLBACK_COLOR}
-                  />
-                ))}
-              </Pie>
-              <Tooltip
-                formatter={(value: number, name: string) => [
-                  `${value} alert${value !== 1 ? 's' : ''}`,
-                  name.replace(/_/g, ' '),
-                ]}
-              />
-              <Legend
-                formatter={(value: string) => (
-                  <span style={{ textTransform: 'capitalize', cursor: 'pointer' }}>
-                    {value.replace(/_/g, ' ')}
-                  </span>
-                )}
-                onClick={(e) => {
-                  const name = String(e.value);
-                  if (chartDimension === 'severity') {
-                    setSeverityFilter(name); setStateFilter('');
-                  } else if (chartDimension === 'state') {
-                    setStateFilter(name); setSeverityFilter('');
-                  }
-                }}
-              />
-            </PieChart>
-          </ResponsiveContainer>
-        ) : (
-          <div className="placeholder">
-            <div className="placeholder__icon">&#x25EF;</div>
-            <div className="placeholder__text">No alert data to display</div>
-          </div>
-        )}
-      </div>
     </div>
   );
 }

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 import { KpiCard } from '@/components/common/KpiCard';
@@ -6,6 +6,7 @@ import { attestationsApi } from '@/api/attestations';
 import { agentsApi } from '@/api/agents';
 import { alertsApi } from '@/api/alerts';
 import { useOutletContext, useNavigate } from 'react-router-dom';
+import type { Alert } from '@/types';
 
 const STATE_COLORS: Record<string, string> = {
   // Pull-mode states
@@ -28,6 +29,40 @@ const PULL_STATES = new Set([
   'GET_QUOTE', 'PROVIDE_V', 'REGISTERED', 'FAILED',
   'RETRY', 'TERMINATED', 'INVALID_QUOTE', 'TENANT_FAILED',
 ]);
+
+type AlertChartDimension = 'severity' | 'type' | 'state';
+
+const ALERT_SEVERITY_COLORS: Record<string, string> = {
+  critical: '#ea4335',
+  warning: '#f9ab00',
+  info: '#1a73e8',
+};
+
+const ALERT_STATE_COLORS: Record<string, string> = {
+  new: '#ea4335',
+  acknowledged: '#f9ab00',
+  under_investigation: '#4285f4',
+  resolved: '#34a853',
+  dismissed: '#9e9e9e',
+};
+
+const ALERT_TYPE_COLORS: Record<string, string> = {
+  attestation_failure: '#ea4335',
+  cert_expiry: '#f9ab00',
+  policy_violation: '#e8710a',
+  pcr_change: '#9334e6',
+  service_down: '#d93025',
+  rate_limit: '#4285f4',
+  clock_skew: '#00897b',
+};
+
+const ALERT_COLOR_MAPS: Record<AlertChartDimension, Record<string, string>> = {
+  severity: ALERT_SEVERITY_COLORS,
+  type: ALERT_TYPE_COLORS,
+  state: ALERT_STATE_COLORS,
+};
+
+const ALERT_FALLBACK_COLOR = '#bdbdbd';
 
 interface StateEntry {
   name: string;
@@ -58,6 +93,14 @@ export function Dashboard() {
     select: (res) => res.data,
   });
 
+  const { data: alertsData } = useQuery({
+    queryKey: ['alerts', 'dashboard'],
+    queryFn: () => alertsApi.list({ per_page: 100 }),
+    select: (res) => res.data,
+  });
+
+  const [alertChartDimension, setAlertChartDimension] = useState<AlertChartDimension>('severity');
+
   const agentItems = useMemo(
     () => Array.isArray(agents?.items) ? agents.items : Array.isArray(agents) ? agents : [],
     [agents]
@@ -80,6 +123,20 @@ export function Dashboard() {
       value: count,
     }));
   }, [agentItems]);
+
+  const alertItems: Alert[] = useMemo(
+    () => Array.isArray(alertsData?.items) ? alertsData.items : Array.isArray(alertsData) ? alertsData : [],
+    [alertsData]
+  );
+
+  const alertChartData = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const alert of alertItems) {
+      const key = alert[alertChartDimension] ?? 'unknown';
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+    return Array.from(counts.entries()).map(([name, value]) => ({ name, value }));
+  }, [alertItems, alertChartDimension]);
 
   return (
     <div>
@@ -123,6 +180,7 @@ export function Dashboard() {
         />
       </div>
 
+      <div className="charts-row">
       <div className="section">
         <h2 className="section__title">Agent State Distribution</h2>
         {stateDistribution.length > 0 ? (
@@ -276,15 +334,101 @@ export function Dashboard() {
       </div>
 
       <div className="section">
-        <h2 className="section__title">Recent Alerts</h2>
-        <div className="placeholder">
-          <div className="placeholder__icon">&#x26A0;</div>
-          <div className="placeholder__text">Alert feed</div>
-          <div className="placeholder__subtext">
-            Real-time alerts will appear here once connected to the backend.
-            Each alert shows severity, affected agents, and recommended actions.
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
+          <h2 className="section__title" style={{ margin: 0 }}>Alert Distribution</h2>
+          <div role="group" aria-label="Alert chart dimension" style={{ display: 'flex', gap: '4px' }}>
+            {(['severity', 'type', 'state'] as AlertChartDimension[]).map((dim) => (
+              <button
+                key={dim}
+                onClick={() => setAlertChartDimension(dim)}
+                style={{
+                  padding: '6px 14px',
+                  fontSize: '13px',
+                  fontWeight: alertChartDimension === dim ? 600 : 400,
+                  border: '1px solid var(--color-border)',
+                  borderRadius: 'var(--radius-sm)',
+                  background: alertChartDimension === dim ? 'var(--color-primary)' : 'var(--color-surface)',
+                  color: alertChartDimension === dim ? '#fff' : 'inherit',
+                  cursor: 'pointer',
+                  textTransform: 'capitalize',
+                }}
+              >
+                {dim}
+              </button>
+            ))}
           </div>
         </div>
+        {alertChartData.length > 0 ? (
+          <ResponsiveContainer width="100%" height={280}>
+            <PieChart>
+              <Pie
+                data={alertChartData}
+                cx="50%"
+                cy="50%"
+                outerRadius={90}
+                innerRadius={45}
+                dataKey="value"
+                nameKey="name"
+                label={({ cx, cy, midAngle, outerRadius, name, value }: {
+                  cx: number; cy: number; midAngle: number; outerRadius: number;
+                  name: string; value: number;
+                }) => {
+                  const RADIAN = Math.PI / 180;
+                  const radius = outerRadius + 18;
+                  const x = cx + radius * Math.cos(-midAngle * RADIAN);
+                  const y = cy + radius * Math.sin(-midAngle * RADIAN);
+                  const colors = ALERT_COLOR_MAPS[alertChartDimension];
+                  return (
+                    <text
+                      x={x} y={y}
+                      fill={colors[name] ?? ALERT_FALLBACK_COLOR}
+                      textAnchor={x > cx ? 'start' : 'end'}
+                      dominantBaseline="central"
+                      fontSize={12}
+                      style={{ cursor: 'pointer' }}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        navigate('/alerts');
+                      }}
+                    >
+                      {`${name.replace(/_/g, ' ')} (${value})`}
+                    </text>
+                  );
+                }}
+                labelLine
+                style={{ cursor: 'pointer' }}
+                onClick={() => navigate('/alerts')}
+              >
+                {alertChartData.map((entry) => (
+                  <Cell
+                    key={entry.name}
+                    fill={ALERT_COLOR_MAPS[alertChartDimension][entry.name] ?? ALERT_FALLBACK_COLOR}
+                  />
+                ))}
+              </Pie>
+              <Tooltip
+                formatter={(value: number, name: string) => [
+                  `${value} alert${value !== 1 ? 's' : ''}`,
+                  name.replace(/_/g, ' '),
+                ]}
+              />
+              <Legend
+                formatter={(value: string) => (
+                  <span style={{ textTransform: 'capitalize', cursor: 'pointer' }}>
+                    {value.replace(/_/g, ' ')}
+                  </span>
+                )}
+                onClick={() => navigate('/alerts')}
+              />
+            </PieChart>
+          </ResponsiveContainer>
+        ) : (
+          <div className="placeholder">
+            <div className="placeholder__icon">&#x25EF;</div>
+            <div className="placeholder__text">No alert data to display</div>
+          </div>
+        )}
+      </div>
       </div>
 
       <div className="section">


### PR DESCRIPTION
Move the Alert Distribution pie chart from the Alerts page to the Dashboard, displayed side by side with the Agent State Distribution chart on wide screens. A CSS media query stacks them vertically on screens narrower than 900px for mobile-friendly layout.