### PR TITLE
Fix Show All buttons not visible in dark mode

### DIFF
--- a/src/pages/Agents/AgentDetail.tsx
+++ b/src/pages/Agents/AgentDetail.tsx
@@ -57,6 +57,7 @@ export function AgentDetailPage() {
             borderRadius: 'var(--radius-sm)',
             padding: '6px 12px',
             fontSize: '14px',
+            color: 'var(--color-text)',
           }}
           aria-label="Back to agents list"
         >

--- a/src/pages/Agents/AgentList.tsx
+++ b/src/pages/Agents/AgentList.tsx
@@ -123,6 +123,7 @@ export function AgentList() {
             border: '1px solid var(--color-border)',
             borderRadius: 'var(--radius-sm)',
             background: 'var(--color-surface)',
+            color: 'var(--color-text)',
             cursor: 'pointer',
           }}
         >

--- a/src/pages/Alerts/Alerts.tsx
+++ b/src/pages/Alerts/Alerts.tsx
@@ -115,6 +115,7 @@ export function Alerts() {
             border: '1px solid var(--color-border)',
             borderRadius: 'var(--radius-sm)',
             background: 'var(--color-surface)',
+            color: 'var(--color-text)',
             cursor: 'pointer',
           }}
         >


### PR DESCRIPTION
Add explicit text color to Show All Agents and Show All Alerts buttons so they render correctly in dark theme.