### PR TITLE
Remove notification bell button from top bar

### DIFF
--- a/src/components/Layout/Layout.css
+++ b/src/components/Layout/Layout.css
@@ -184,15 +184,6 @@
   gap: 4px;
 }
 
-.topbar__notifications {
-  position: relative;
-  background: none;
-  border: none;
-  font-size: 18px;
-  color: var(--color-text-secondary);
-  padding: 4px;
-}
-
 .topbar__theme-toggle {
   background: none;
   border: 1px solid var(--color-border);
@@ -207,23 +198,6 @@
 .topbar__theme-toggle:hover {
   background: var(--color-bg);
   color: var(--color-text);
-}
-
-.topbar__badge {
-  position: absolute;
-  top: -2px;
-  right: -4px;
-  background: var(--color-danger);
-  color: white;
-  font-size: 10px;
-  font-weight: 700;
-  min-width: 16px;
-  height: 16px;
-  border-radius: 8px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0 4px;
 }
 
 .topbar__settings {

--- a/src/components/Layout/TopBar.tsx
+++ b/src/components/Layout/TopBar.tsx
@@ -1,9 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
 import { TIME_RANGES } from '@/types';
 import { useAuth } from '@/hooks/useAuth';
-import { alertsApi } from '@/api/alerts';
 import { useVisualizationStore } from '@/store/visualizationStore';
 
 interface TopBarProps {
@@ -25,14 +23,6 @@ export function TopBar({ selectedTimeRange, onTimeRangeChange }: TopBarProps) {
       setSearch('');
     }
   };
-
-  const { data: alertSummary } = useQuery({
-    queryKey: ['alerts', 'summary'],
-    queryFn: () => alertsApi.summary(),
-    select: (res) => res.data,
-  });
-
-  const alertCount = (alertSummary?.critical ?? 0) + (alertSummary?.warnings ?? 0);
 
   const initials = user?.name
     ? user.name
@@ -73,15 +63,6 @@ export function TopBar({ selectedTimeRange, onTimeRangeChange }: TopBarProps) {
             </button>
           ))}
         </div>
-
-        <button
-          className="topbar__notifications"
-          aria-label="Notifications"
-          onClick={() => navigate('/alerts')}
-        >
-          &#x1F514;
-          {alertCount > 0 && <span className="topbar__badge">{alertCount}</span>}
-        </button>
 
         <div className="topbar__actions">
           <button


### PR DESCRIPTION
The bell icon and alert badge in the top bar were distracting. Alerts are still accessible via the Alerts page in the sidebar navigation.