### PR TITLE
Fix dark mode text visibility across all pages

### DIFF
--- a/src/pages/Agents/AgentDetail.tsx
+++ b/src/pages/Agents/AgentDetail.tsx
@@ -309,6 +309,7 @@ function RawTab({ agentId }: { agentId: string }) {
       <pre
         style={{
           background: 'var(--color-bg)',
+          color: 'var(--color-text)',
           padding: '16px',
           borderRadius: 'var(--radius-sm)',
           overflow: 'auto',

--- a/src/pages/Agents/AgentList.tsx
+++ b/src/pages/Agents/AgentList.tsx
@@ -153,6 +153,8 @@ export function AgentList() {
             border: '1px solid var(--color-border)',
             borderRadius: 'var(--radius-sm)',
             fontSize: '14px',
+            color: 'var(--color-text)',
+            background: 'var(--color-surface)',
           }}
           aria-label="Search agents"
         />
@@ -175,6 +177,8 @@ export function AgentList() {
             border: '1px solid var(--color-border)',
             borderRadius: 'var(--radius-sm)',
             fontSize: '14px',
+            color: 'var(--color-text)',
+            background: 'var(--color-surface)',
           }}
           aria-label="Filter by state"
         >
@@ -214,6 +218,8 @@ export function AgentList() {
             border: '1px solid var(--color-border)',
             borderRadius: 'var(--radius-sm)',
             fontSize: '14px',
+            color: 'var(--color-text)',
+            background: 'var(--color-surface)',
           }}
           aria-label="Filter by mode"
         >
@@ -241,7 +247,7 @@ export function AgentList() {
               <button
                 onClick={() => setPage((p) => Math.max(1, p - 1))}
                 disabled={page <= 1}
-                style={{ padding: '6px 16px', borderRadius: 'var(--radius-sm)', border: '1px solid var(--color-border)', background: 'var(--color-surface)' }}
+                style={{ padding: '6px 16px', borderRadius: 'var(--radius-sm)', border: '1px solid var(--color-border)', background: 'var(--color-surface)', color: 'var(--color-text)' }}
               >
                 Previous
               </button>
@@ -251,7 +257,7 @@ export function AgentList() {
               <button
                 onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
                 disabled={page >= totalPages}
-                style={{ padding: '6px 16px', borderRadius: 'var(--radius-sm)', border: '1px solid var(--color-border)', background: 'var(--color-surface)' }}
+                style={{ padding: '6px 16px', borderRadius: 'var(--radius-sm)', border: '1px solid var(--color-border)', background: 'var(--color-surface)', color: 'var(--color-text)' }}
               >
                 Next
               </button>

--- a/src/pages/Alerts/Alerts.tsx
+++ b/src/pages/Alerts/Alerts.tsx
@@ -84,6 +84,7 @@ export function Alerts() {
                 border: '1px solid var(--color-border)',
                 borderRadius: 'var(--radius-sm)',
                 background: 'var(--color-surface)',
+                color: 'var(--color-text)',
               }}
             >
               Ack
@@ -97,6 +98,7 @@ export function Alerts() {
                 border: '1px solid var(--color-border)',
                 borderRadius: 'var(--radius-sm)',
                 background: 'var(--color-surface)',
+                color: 'var(--color-text)',
               }}
             >
               Investigate
@@ -164,7 +166,7 @@ export function Alerts() {
         <select
           value={severityFilter}
           onChange={(e) => setSeverityFilter(e.target.value)}
-          style={{ padding: '8px 12px', border: '1px solid var(--color-border)', borderRadius: 'var(--radius-sm)', fontSize: '14px' }}
+          style={{ padding: '8px 12px', border: '1px solid var(--color-border)', borderRadius: 'var(--radius-sm)', fontSize: '14px', color: 'var(--color-text)', background: 'var(--color-surface)' }}
           aria-label="Filter by severity"
         >
           <option value="">All severities</option>
@@ -175,7 +177,7 @@ export function Alerts() {
         <select
           value={stateFilter}
           onChange={(e) => setStateFilter(e.target.value)}
-          style={{ padding: '8px 12px', border: '1px solid var(--color-border)', borderRadius: 'var(--radius-sm)', fontSize: '14px' }}
+          style={{ padding: '8px 12px', border: '1px solid var(--color-border)', borderRadius: 'var(--radius-sm)', fontSize: '14px', color: 'var(--color-text)', background: 'var(--color-surface)' }}
           aria-label="Filter by state"
         >
           <option value="">All states</option>
@@ -188,7 +190,7 @@ export function Alerts() {
         <select
           value={typeFilter}
           onChange={(e) => setTypeFilter(e.target.value)}
-          style={{ padding: '8px 12px', border: '1px solid var(--color-border)', borderRadius: 'var(--radius-sm)', fontSize: '14px' }}
+          style={{ padding: '8px 12px', border: '1px solid var(--color-border)', borderRadius: 'var(--radius-sm)', fontSize: '14px', color: 'var(--color-text)', background: 'var(--color-surface)' }}
           aria-label="Filter by type"
         >
           <option value="">All types</option>

--- a/src/pages/AuditLog/AuditLog.tsx
+++ b/src/pages/AuditLog/AuditLog.tsx
@@ -72,7 +72,7 @@ export function AuditLog() {
         <select
           value={severity}
           onChange={(e) => setSeverity(e.target.value)}
-          style={{ padding: '8px 12px', border: '1px solid var(--color-border)', borderRadius: 'var(--radius-sm)', fontSize: '14px' }}
+          style={{ padding: '8px 12px', border: '1px solid var(--color-border)', borderRadius: 'var(--radius-sm)', fontSize: '14px', color: 'var(--color-text)', background: 'var(--color-surface)' }}
           aria-label="Filter by severity"
         >
           <option value="">All severities</option>
@@ -87,6 +87,7 @@ export function AuditLog() {
             border: '1px solid var(--color-border)',
             borderRadius: 'var(--radius-sm)',
             background: 'var(--color-surface)',
+            color: 'var(--color-text)',
             fontSize: '14px',
           }}
         >
@@ -98,6 +99,7 @@ export function AuditLog() {
             border: '1px solid var(--color-border)',
             borderRadius: 'var(--radius-sm)',
             background: 'var(--color-surface)',
+            color: 'var(--color-text)',
             fontSize: '14px',
           }}
         >

--- a/src/pages/Certificates/Certificates.tsx
+++ b/src/pages/Certificates/Certificates.tsx
@@ -47,6 +47,7 @@ export function Certificates() {
             border: '1px solid var(--color-border)',
             borderRadius: 'var(--radius-sm)',
             background: 'var(--color-surface)',
+            color: 'var(--color-text)',
           }}
         >
           View

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -155,7 +155,7 @@ export function Dashboard() {
                   border: '1px solid var(--color-border)',
                   borderRadius: 'var(--radius-sm)',
                   background: alertChartDimension === dim ? 'var(--color-primary)' : 'var(--color-surface)',
-                  color: alertChartDimension === dim ? '#fff' : 'inherit',
+                  color: alertChartDimension === dim ? '#fff' : 'var(--color-text)',
                   cursor: 'pointer',
                   textTransform: 'capitalize',
                 }}

--- a/src/pages/Policies/Policies.tsx
+++ b/src/pages/Policies/Policies.tsx
@@ -65,6 +65,8 @@ export function Policies() {
             border: '1px solid var(--color-border)',
             borderRadius: 'var(--radius-sm)',
             fontSize: '14px',
+            color: 'var(--color-text)',
+            background: 'var(--color-surface)',
           }}
           aria-label="Search policies"
         />
@@ -85,6 +87,7 @@ export function Policies() {
           style={{
             padding: '8px 20px',
             background: 'var(--color-surface)',
+            color: 'var(--color-text)',
             border: '1px solid var(--color-border)',
             borderRadius: 'var(--radius-sm)',
             fontSize: '14px',

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -217,6 +217,7 @@ export function Settings() {
                           border: '1px solid var(--color-border)',
                           borderRadius: 'var(--radius-sm)',
                           background: 'var(--color-surface)',
+                          color: 'var(--color-text)',
                         }}
                       >
                         View Report


### PR DESCRIPTION
Add explicit color and background CSS variables to inline-styled inputs, selects, and buttons that were missing them, causing text to be invisible in dark mode. Affects AgentList, AgentDetail, Alerts, AuditLog, Certificates, Dashboard, Policies, and Settings pages.