### PR TITLE
Fix top bar input text not visible in dark mode

### DIFF
--- a/src/components/Layout/Layout.css
+++ b/src/components/Layout/Layout.css
@@ -131,6 +131,7 @@
   border-radius: var(--radius-md);
   font-size: 14px;
   background: var(--color-bg);
+  color: var(--color-text);
   outline: none;
   transition: border-color 0.15s;
 }


### PR DESCRIPTION
Add explicit color to the topbar search input so typed text renders correctly against the dark background.