### PR TITLE
Add Signed-off-by commit check and verify script

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+exec "$REPO_ROOT/scripts/check-signed-commits.sh" "$1"

--- a/.github/workflows/signed-commits.yml
+++ b/.github/workflows/signed-commits.yml
@@ -1,0 +1,9 @@
+name: Signed commits
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-signed:
+    uses: keylime-webtool/.github/.github/workflows/signed-commits.yml@main

--- a/scripts/check-signed-commits.sh
+++ b/scripts/check-signed-commits.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# check-signed-commits.sh — Verify a commit message carries a Signed-off-by line.
+#
+# Used as a local commit-msg hook:
+#   bash scripts/check-signed-commits.sh <commit-msg-file>
+#
+# CI validation is handled by the org-wide reusable workflow at:
+#   keylime-webtool/.github/.github/workflows/signed-commits.yml
+
+set -euo pipefail
+
+# ── Colours (disabled when stdout is not a terminal) ──────────────────
+if [ -t 1 ]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    BOLD='\033[1m'
+    RESET='\033[0m'
+else
+    RED='' GREEN='' BOLD='' RESET=''
+fi
+
+die() { echo -e "${RED}${BOLD}ERROR:${RESET} $*" >&2; exit 1; }
+
+COMMIT_MSG_FILE="${1:-}"
+[ -n "$COMMIT_MSG_FILE" ] || die "Usage: $0 <commit-msg-file>"
+[ -f "$COMMIT_MSG_FILE" ] || die "File not found: $COMMIT_MSG_FILE"
+
+MSG=$(cat "$COMMIT_MSG_FILE")
+
+echo -e "${BOLD}Checking Signed-off-by...${RESET}"
+echo ""
+
+if echo "$MSG" | grep -qP '^Signed-off-by: .+ <.+>'; then
+    echo -e "  commit message  ${GREEN}OK${RESET}"
+    echo ""
+    echo -e "${GREEN}${BOLD}Signed-off-by present.${RESET}"
+else
+    echo -e "  commit message  ${RED}MISSING Signed-off-by${RESET}"
+    echo ""
+    echo -e "${RED}Commit message must include a Signed-off-by line.${RESET}"
+    echo ""
+    echo "Add it with:  git commit -s"
+    echo "Or amend:     git commit --amend -s"
+    exit 1
+fi

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# verify.sh — Run all commit checks: code quality + commit message.
+#
+# Combines the pre-commit checks (type check, lint, test, build, audit)
+# with the Signed-off-by verification on the latest commit.
+#
+# Usage:
+#   bash scripts/verify.sh          # run all checks
+#   bash scripts/verify.sh --quick  # skip slow checks (npm audit)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Colours (disabled when stdout is not a terminal) ──────────────────
+if [ -t 1 ]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    BOLD='\033[1m'
+    RESET='\033[0m'
+else
+    RED='' GREEN='' BOLD='' RESET=''
+fi
+
+overall=0
+
+# ── 1. Code quality checks (pre-commit) ──────────────────────────────
+echo -e "${BOLD}=== Code quality checks ===${RESET}"
+echo ""
+if ! bash "$SCRIPT_DIR/pre-commit.sh" "$@"; then
+    overall=1
+fi
+
+echo ""
+
+# ── 2. Signed-off-by check (last commit) ─────────────────────────────
+echo -e "${BOLD}=== Commit message checks ===${RESET}"
+echo ""
+
+if git rev-parse HEAD &>/dev/null; then
+    LAST_MSG=$(git log -1 --format='%B')
+    SHORT=$(git log -1 --format='%h %s' | head -c 72)
+
+    printf "  %-20s" "Signed-off-by"
+    if echo "$LAST_MSG" | grep -qP '^Signed-off-by: .+ <.+>'; then
+        echo -e "${GREEN}OK${RESET}  ($SHORT)"
+    else
+        echo -e "${RED}FAIL${RESET}  ($SHORT)"
+        overall=1
+    fi
+else
+    printf "  %-20s" "Signed-off-by"
+    echo "SKIP (no commits)"
+fi
+
+echo ""
+
+# ── Summary ──────────────────────────────────────────────────────────
+if [ "$overall" -eq 0 ]; then
+    echo -e "${GREEN}${BOLD}All checks passed.${RESET}"
+else
+    echo -e "${RED}${BOLD}Some checks failed.${RESET}"
+    exit 1
+fi


### PR DESCRIPTION
Add a commit-msg hook that rejects commits without a Signed-off-by line, a CI workflow that calls the org-wide reusable workflow for PR validation, and a verify.sh script that runs all checks (code quality plus sign-off) in a single command.