### PR TITLE
Wire attestation timeline chart to backend data

### DIFF
--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -1,6 +1,9 @@
 import { useState, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { PieChart, Pie, Cell, Legend, ResponsiveContainer } from 'recharts';
+import {
+  PieChart, Pie, Cell, Legend, ResponsiveContainer,
+  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip,
+} from 'recharts';
 import { KpiCard } from '@/components/common/KpiCard';
 import { AgentStateChart } from '@/components/common/AgentStateChart';
 import { attestationsApi } from '@/api/attestations';
@@ -67,6 +70,22 @@ export function Dashboard() {
     queryFn: () => attestationsApi.summary(timeRange),
     select: (res) => res.data,
   });
+
+  const { data: attestationTimeline } = useQuery({
+    queryKey: ['attestations', 'timeline', timeRange],
+    queryFn: () => attestationsApi.timeline(timeRange),
+    select: (res) => res.data,
+  });
+
+  const timelineData = useMemo(() => {
+    const raw = Array.isArray(attestationTimeline) ? attestationTimeline : [];
+    return raw.map((point) => ({
+      ...point,
+      label: new Date(point.hour).toLocaleString(undefined, {
+        month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+      }),
+    }));
+  }, [attestationTimeline]);
 
   const { data: alertSummary } = useQuery({
     queryKey: ['alerts', 'summary'],
@@ -260,13 +279,33 @@ export function Dashboard() {
 
       <div className="section">
         <h2 className="section__title">Attestation Success Rate ({timeRange})</h2>
-        <div className="placeholder">
-          <div className="placeholder__icon">&#x1F4CA;</div>
-          <div className="placeholder__text">Timeline chart</div>
-          <div className="placeholder__subtext">
-            A time-series chart showing attestation success/failure rates over the selected time range.
+        {timelineData.length > 0 ? (
+          <ResponsiveContainer width="100%" height={280}>
+            <BarChart data={timelineData}>
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+              <XAxis dataKey="label" fontSize={11} tick={{ fill: 'var(--color-text-secondary)' }} />
+              <YAxis fontSize={11} tick={{ fill: 'var(--color-text-secondary)' }} />
+              <Tooltip
+                contentStyle={{
+                  background: 'var(--color-surface)',
+                  border: '1px solid var(--color-border)',
+                  borderRadius: 'var(--radius-sm)',
+                  color: 'var(--color-text)',
+                }}
+              />
+              <Bar dataKey="successful" name="Successful" fill="#34a853" stackId="a" />
+              <Bar dataKey="failed" name="Failed" fill="#ea4335" stackId="a" />
+            </BarChart>
+          </ResponsiveContainer>
+        ) : (
+          <div className="placeholder">
+            <div className="placeholder__icon">&#x1F4CA;</div>
+            <div className="placeholder__text">No attestation timeline data</div>
+            <div className="placeholder__subtext">
+              Attestation history will appear here once the backend records pass/fail events.
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
Replace the static placeholder with a stacked bar chart that fetches from /api/attestations/timeline and renders successful/failed counts per hour using Recharts.