### PR TITLE
Capitalize alert pie chart labels to match legend style

### DIFF
--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -238,7 +238,7 @@ export function Dashboard() {
                         navigate(`/alerts?${alertChartDimension}=${encodeURIComponent(name)}`);
                       }}
                     >
-                      {`${name.replace(/_/g, ' ')} (${value})`}
+                      {`${name.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())} (${value})`}
                     </text>
                   );
                 }}


### PR DESCRIPTION
Apply title case to pie chart slice labels so they are consistent with the legend which already uses text-transform: capitalize.