### PR TITLE
Link policy agent counts to filtered agent list

### DIFF
--- a/src/pages/Agents/AgentList.tsx
+++ b/src/pages/Agents/AgentList.tsx
@@ -28,6 +28,7 @@ export function AgentList() {
   const [page, setPage] = useState(1);
   const [stateFilter, setStateFilter] = useState<string>(searchParams.get('state') ?? '');
   const [modeFilter, setModeFilter] = useState<string>(searchParams.get('mode') ?? '');
+  const [policyFilter, setPolicyFilter] = useState<string>(searchParams.get('policy') ?? '');
   const [search, setSearch] = useState(searchParams.get('q') ?? '');
 
   // Sync search and state filter when URL query params change
@@ -35,9 +36,11 @@ export function AgentList() {
     const q = searchParams.get('q') ?? '';
     const state = searchParams.get('state') ?? '';
     const mode = searchParams.get('mode') ?? '';
+    const policy = searchParams.get('policy') ?? '';
     setSearch(q);
     setStateFilter(state);
     setModeFilter(mode);
+    setPolicyFilter(policy);
     setPage(1);
   }, [searchParams]);
 
@@ -62,9 +65,9 @@ export function AgentList() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const rawItems = (data as any)?.items ?? data;
   const allItems: AgentRow[] = Array.isArray(rawItems) ? rawItems : [];
-  const items = modeFilter
-    ? allItems.filter((a) => a.attestation_mode === modeFilter)
-    : allItems;
+  let items = allItems;
+  if (modeFilter) items = items.filter((a) => a.attestation_mode === modeFilter);
+  if (policyFilter) items = items.filter((a) => a.assigned_policy === policyFilter || a.mb_policy === policyFilter);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const totalPages = (data as any)?.total_pages ?? 1;
 
@@ -115,6 +118,7 @@ export function AgentList() {
             setSearch('');
             setStateFilter('');
             setModeFilter('');
+            setPolicyFilter('');
             setPage(1);
             setSearchParams({});
           }}

--- a/src/pages/Policies/Policies.tsx
+++ b/src/pages/Policies/Policies.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { DataTable } from '@/components/common/DataTable';
 import { StatusBadge } from '@/components/common/StatusBadge';
@@ -31,7 +32,24 @@ export function Policies() {
         <StatusBadge label={KIND_LABELS[row.kind] ?? row.kind ?? '--'} variant="info" />
       ),
     },
-    { key: 'assigned_agents', header: 'Agents', sortable: true },
+    {
+      key: 'assigned_agents',
+      header: 'Agents',
+      sortable: true,
+      render: (row: Policy) => {
+        const count = row.assigned_agents ?? 0;
+        if (count === 0) return <span>0</span>;
+        return (
+          <Link
+            to={`/agents?policy=${encodeURIComponent(row.name)}`}
+            style={{ color: 'var(--color-primary)', fontWeight: 500 }}
+            title={`View agents with policy "${row.name}"`}
+          >
+            {count}
+          </Link>
+        );
+      },
+    },
     { key: 'checksum', header: 'Checksum', render: (row: Policy) => (
       <span style={{ fontFamily: 'monospace', fontSize: '12px' }}>
         {row.checksum ? `${row.checksum.substring(0, 12)}...` : '--'}


### PR DESCRIPTION
Make the Agents column in the Policies table a clickable link that navigates to /agents?policy=<name>, filtering the agent list to show only agents assigned to that policy.