### PR TITLE
Fix backend health check. Add backend URL config

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,12 +1,51 @@
 import axios from 'axios';
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
+const BACKEND_URL_KEY = 'backend-url';
+const DEFAULT_BACKEND_URL = 'http://localhost:8080';
+
+/**
+ * Returns the base URL used for API requests.
+ * - In dev mode (Vite dev server), always returns '' so requests go through the
+ *   Vite proxy (same-origin /api/*) and avoid CORS issues.
+ * - In production, uses a user-configured URL from localStorage, VITE_API_BASE_URL,
+ *   or '' (for reverse-proxy setups where backend is on the same origin).
+ */
+function getBaseURL(): string {
+  if (import.meta.env.DEV) return '';
+  const saved = localStorage.getItem(BACKEND_URL_KEY);
+  if (saved) return saved.replace(/\/+$/, '');
+  return import.meta.env.VITE_API_BASE_URL || '';
+}
+
+/**
+ * Returns the backend URL for display purposes (Settings, Integrations).
+ * Always resolves to a human-readable URL even when getBaseURL() is empty.
+ */
+export function getBackendUrl(): string {
+  const saved = localStorage.getItem(BACKEND_URL_KEY);
+  if (saved) return saved.replace(/\/+$/, '');
+  return import.meta.env.VITE_API_BASE_URL || DEFAULT_BACKEND_URL;
+}
+
+export function setBackendUrl(url: string): void {
+  const trimmed = url.trim().replace(/\/+$/, '');
+  if (trimmed) {
+    localStorage.setItem(BACKEND_URL_KEY, trimmed);
+  } else {
+    localStorage.removeItem(BACKEND_URL_KEY);
+  }
+}
 
 const apiClient = axios.create({
-  baseURL: `${API_BASE_URL}/api`,
   headers: {
     'Content-Type': 'application/json',
   },
+});
+
+// Set baseURL dynamically on every request so changes take effect immediately.
+apiClient.interceptors.request.use((config) => {
+  config.baseURL = `${getBaseURL()}/api`;
+  return config;
 });
 
 apiClient.interceptors.request.use((config) => {

--- a/src/pages/Integrations/Integrations.tsx
+++ b/src/pages/Integrations/Integrations.tsx
@@ -3,16 +3,10 @@ import { useQuery } from '@tanstack/react-query';
 import { StatusBadge } from '@/components/common/StatusBadge';
 import { performanceApi } from '@/api/performance';
 import { settingsApi } from '@/api/settings';
+import { getBackendUrl } from '@/api/client';
 import type { IntegrationService } from '@/types';
 
 export function Integrations() {
-  const { data: services, isLoading } = useQuery({
-    queryKey: ['integrations', 'status'],
-    queryFn: () => performanceApi.integrations(),
-    select: (res) => res.data,
-    refetchInterval: 1000,
-  });
-
   // Backend health: try fetching the settings endpoint (lightweight).
   // If it responds, backend is up; if it throws, it's down.
   const { data: backendResult, isLoading: backendLoading } = useQuery({
@@ -29,11 +23,21 @@ export function Integrations() {
     refetchInterval: 1000,
   });
 
+  const backendUp = backendResult?.status === 'up';
+
+  const { data: services, isLoading } = useQuery({
+    queryKey: ['integrations', 'status'],
+    queryFn: () => performanceApi.integrations(),
+    select: (res) => res.data,
+    refetchInterval: 1000,
+    enabled: backendUp,
+  });
+
   const backendService: IntegrationService | null = useMemo(() => {
     if (!backendResult) return null;
     return {
       name: 'keylime-webtool-backend',
-      address: import.meta.env.VITE_API_BASE_URL || window.location.origin,
+      address: getBackendUrl(),
       status: backendResult.status,
       latency_ms: backendResult.latency_ms,
     };
@@ -81,9 +85,16 @@ export function Integrations() {
         ) : null}
       </div>
 
-      <div className="section">
+      <div className="section" style={{ opacity: backendUp ? 1 : 0.5 }}>
         <h2 className="section__title">Core Services</h2>
-        {isLoading ? (
+        {!backendUp ? (
+          <div className="placeholder">
+            <div className="placeholder__text">Backend unavailable</div>
+            <div className="placeholder__subtext">
+              Core service status requires a connection to the webtool backend.
+            </div>
+          </div>
+        ) : isLoading ? (
           <div className="placeholder">
             <div className="placeholder__text">Loading service status...</div>
           </div>
@@ -128,12 +139,12 @@ export function Integrations() {
         )}
       </div>
 
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '24px' }}>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '24px', opacity: backendUp ? 1 : 0.5 }}>
         <div className="section">
           <h2 className="section__title">Attestation Backends</h2>
           <div className="placeholder">
             <div className="placeholder__icon">&#x1F4E6;</div>
-            <div className="placeholder__text">Durable backends</div>
+            <div className="placeholder__text">{backendUp ? 'Durable backends' : 'Backend unavailable'}</div>
             <div className="placeholder__subtext">
               Rekor, Redis, and RFC 3161 TSA status with connection state and latency.
             </div>
@@ -144,7 +155,7 @@ export function Integrations() {
           <h2 className="section__title">Notification Channels</h2>
           <div className="placeholder">
             <div className="placeholder__icon">&#x1F514;</div>
-            <div className="placeholder__text">Notification delivery</div>
+            <div className="placeholder__text">{backendUp ? 'Notification delivery' : 'Backend unavailable'}</div>
             <div className="placeholder__subtext">
               ZeroMQ, Webhook, and Agent notification channel status.
             </div>

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAuth } from '@/hooks/useAuth';
 import { useVisualizationStore } from '@/store/visualizationStore';
 import { settingsApi } from '@/api/settings';
+import { getBackendUrl, setBackendUrl } from '@/api/client';
 import type { KeylimeSettings } from '@/api/settings';
 import { TIME_RANGES } from '@/types';
 
@@ -85,17 +86,21 @@ export function Settings() {
     },
   });
 
-  const handleSaveKeylime = () => {
+  const handleSaveKeylime = (_field?: string) => {
     updateMutation.mutate({
       verifier_url: verifierUrl.trim(),
       registrar_url: registrarUrl.trim(),
     });
   };
 
-  const keylimeChanged =
-    formLoaded &&
-    (verifierUrl !== keylimeSettings?.verifier_url ||
-      registrarUrl !== keylimeSettings?.registrar_url);
+  const [backendUrlInitial] = useState(() => getBackendUrl());
+  const [backendUrlField, setBackendUrlField] = useState(backendUrlInitial);
+
+  const handleSaveBackendUrl = () => {
+    setBackendUrl(backendUrlField);
+    queryClient.invalidateQueries();
+    window.location.reload();
+  };
 
   const sections = [
     { key: 'keylime', label: 'Keylime Connection' },
@@ -147,61 +152,101 @@ export function Settings() {
               <div>
                 <div style={settingRowStyle}>
                   <div style={{ flex: 1 }}>
-                    <div style={settingLabelStyle}>Verifier URL</div>
-                    <div style={settingDescStyle}>Base URL of the Keylime Verifier API</div>
+                    <div style={settingLabelStyle}>Backend URL</div>
+                    <div style={settingDescStyle}>Base URL of the Keylime Webtool Backend API</div>
                   </div>
-                  <input
-                    type="text"
-                    value={verifierUrl}
-                    onChange={(e) => setVerifierUrl(e.target.value)}
-                    placeholder="http://localhost:8881"
-                    style={{ ...selectStyle, width: '320px' }}
-                    aria-label="Verifier URL"
-                  />
+                  <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+                    <input
+                      type="text"
+                      value={backendUrlField}
+                      onChange={(e) => setBackendUrlField(e.target.value)}
+                      placeholder="http://localhost:8080"
+                      style={{ ...selectStyle, width: '260px' }}
+                      aria-label="Backend URL"
+                    />
+                    <button
+                      onClick={handleSaveBackendUrl}
+                      disabled={backendUrlField === backendUrlInitial}
+                      style={{
+                        padding: '6px 16px',
+                        fontSize: '13px',
+                        fontWeight: 500,
+                        border: 'none',
+                        borderRadius: 'var(--radius-sm)',
+                        background: backendUrlField !== backendUrlInitial ? 'var(--color-primary)' : 'var(--color-border)',
+                        color: backendUrlField !== backendUrlInitial ? 'white' : 'var(--color-text-secondary)',
+                        cursor: backendUrlField !== backendUrlInitial ? 'pointer' : 'default',
+                      }}
+                    >
+                      Apply
+                    </button>
+                  </div>
                 </div>
 
                 <div style={settingRowStyle}>
                   <div style={{ flex: 1 }}>
+                    <div style={settingLabelStyle}>Verifier URL</div>
+                    <div style={settingDescStyle}>Base URL of the Keylime Verifier API</div>
+                  </div>
+                  <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+                    <input
+                      type="text"
+                      value={verifierUrl}
+                      onChange={(e) => setVerifierUrl(e.target.value)}
+                      placeholder="http://localhost:8881"
+                      style={{ ...selectStyle, width: '260px' }}
+                      aria-label="Verifier URL"
+                    />
+                    <button
+                      onClick={() => handleSaveKeylime('verifier')}
+                      disabled={!formLoaded || verifierUrl === keylimeSettings?.verifier_url || saveStatus === 'saving'}
+                      style={{
+                        padding: '6px 16px',
+                        fontSize: '13px',
+                        fontWeight: 500,
+                        border: 'none',
+                        borderRadius: 'var(--radius-sm)',
+                        background: formLoaded && verifierUrl !== keylimeSettings?.verifier_url ? 'var(--color-primary)' : 'var(--color-border)',
+                        color: formLoaded && verifierUrl !== keylimeSettings?.verifier_url ? 'white' : 'var(--color-text-secondary)',
+                        cursor: formLoaded && verifierUrl !== keylimeSettings?.verifier_url ? 'pointer' : 'default',
+                      }}
+                    >
+                      Apply
+                    </button>
+                  </div>
+                </div>
+
+                <div style={{ ...settingRowStyle, borderBottom: 'none' }}>
+                  <div style={{ flex: 1 }}>
                     <div style={settingLabelStyle}>Registrar URL</div>
                     <div style={settingDescStyle}>Base URL of the Keylime Registrar API</div>
                   </div>
-                  <input
-                    type="text"
-                    value={registrarUrl}
-                    onChange={(e) => setRegistrarUrl(e.target.value)}
-                    placeholder="http://localhost:8890"
-                    style={{ ...selectStyle, width: '320px' }}
-                    aria-label="Registrar URL"
-                  />
-                </div>
-
-                <div style={{ ...settingRowStyle, borderBottom: 'none', justifyContent: 'flex-end', gap: '12px' }}>
-                  {saveStatus === 'saved' && (
-                    <span style={{ color: 'var(--color-success, #34a853)', fontSize: '14px' }}>
-                      Settings saved
-                    </span>
-                  )}
-                  {saveStatus === 'error' && (
-                    <span style={{ color: 'var(--color-danger, #ea4335)', fontSize: '14px' }}>
-                      Failed to save
-                    </span>
-                  )}
-                  <button
-                    onClick={handleSaveKeylime}
-                    disabled={!keylimeChanged || saveStatus === 'saving'}
-                    style={{
-                      padding: '8px 24px',
-                      fontSize: '14px',
-                      fontWeight: 500,
-                      border: 'none',
-                      borderRadius: 'var(--radius-sm)',
-                      background: keylimeChanged ? 'var(--color-primary)' : 'var(--color-border)',
-                      color: keylimeChanged ? 'white' : 'var(--color-text-secondary)',
-                      cursor: keylimeChanged ? 'pointer' : 'default',
-                    }}
-                  >
-                    {saveStatus === 'saving' ? 'Saving...' : 'Save'}
-                  </button>
+                  <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+                    <input
+                      type="text"
+                      value={registrarUrl}
+                      onChange={(e) => setRegistrarUrl(e.target.value)}
+                      placeholder="http://localhost:8890"
+                      style={{ ...selectStyle, width: '260px' }}
+                      aria-label="Registrar URL"
+                    />
+                    <button
+                      onClick={() => handleSaveKeylime('registrar')}
+                      disabled={!formLoaded || registrarUrl === keylimeSettings?.registrar_url || saveStatus === 'saving'}
+                      style={{
+                        padding: '6px 16px',
+                        fontSize: '13px',
+                        fontWeight: 500,
+                        border: 'none',
+                        borderRadius: 'var(--radius-sm)',
+                        background: formLoaded && registrarUrl !== keylimeSettings?.registrar_url ? 'var(--color-primary)' : 'var(--color-border)',
+                        color: formLoaded && registrarUrl !== keylimeSettings?.registrar_url ? 'white' : 'var(--color-text-secondary)',
+                        cursor: formLoaded && registrarUrl !== keylimeSettings?.registrar_url ? 'pointer' : 'default',
+                      }}
+                    >
+                      Apply
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Use Vite proxy in dev mode to avoid CORS failures when checking backend health. Add Backend URL field to Settings with per-field Apply buttons. Disable Integrations sections (Core Services, Attestation Backends, Notification Channels) when the backend is unreachable and auto-recover when it comes back.