### PR TITLE
Align IntegrationService field name with backend

### DIFF
--- a/src/pages/Integrations/Integrations.tsx
+++ b/src/pages/Integrations/Integrations.tsx
@@ -37,7 +37,7 @@ export function Integrations() {
     if (!backendResult) return null;
     return {
       name: 'keylime-webtool-backend',
-      address: getBackendUrl(),
+      endpoint: getBackendUrl(),
       status: backendResult.status,
       latency_ms: backendResult.latency_ms,
     };
@@ -71,7 +71,7 @@ export function Integrations() {
               <div>
                 <div style={{ fontWeight: 600, fontSize: '14px' }}>{backendService.name}</div>
                 <div style={{ fontSize: '12px', color: 'var(--color-text-secondary)' }}>
-                  {backendService.address}
+                  {backendService.endpoint}
                 </div>
                 {backendService.latency_ms !== undefined && (
                   <div style={{ fontSize: '12px', color: 'var(--color-text-secondary)' }}>
@@ -115,7 +115,7 @@ export function Integrations() {
                 <div>
                   <div style={{ fontWeight: 600, fontSize: '14px' }}>{svc.name}</div>
                   <div style={{ fontSize: '12px', color: 'var(--color-text-secondary)' }}>
-                    {svc.address}
+                    {svc.endpoint}
                   </div>
                   {svc.latency_ms !== undefined && (
                     <div style={{ fontSize: '12px', color: 'var(--color-text-secondary)' }}>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -26,7 +26,7 @@ export type ServiceStatus = 'up' | 'down' | 'high_load' | 'timeout' | 'not_confi
 
 export interface IntegrationService {
   name: string;
-  address: string;
+  endpoint: string;
   status: ServiceStatus;
   uptime?: string;
   latency_ms?: number;


### PR DESCRIPTION
Rename IntegrationService.address to endpoint to match the backend ServiceHealth struct, so Core Services cards display the configured Verifier and Registrar URLs.