### PR TITLE
Add error state display and missing agent states

### DIFF
--- a/src/pages/Agents/AgentList.tsx
+++ b/src/pages/Agents/AgentList.tsx
@@ -46,7 +46,7 @@ export function AgentList() {
 
   const isSearchMode = search.trim().length > 0;
 
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, error } = useQuery({
     queryKey: ['agents', page, stateFilter, modeFilter, search],
     queryFn: async () => {
       if (isSearchMode) {
@@ -236,6 +236,13 @@ export function AgentList() {
       {isLoading ? (
         <div className="placeholder">
           <div className="placeholder__text">Loading agents...</div>
+        </div>
+      ) : error ? (
+        <div className="placeholder">
+          <div className="placeholder__text">Failed to load agents</div>
+          <div className="placeholder__subtext" style={{ color: 'var(--color-danger, #ea4335)' }}>
+            {(error as Error).message || 'Could not reach the backend. Check Settings and Integrations.'}
+          </div>
         </div>
       ) : (
         <>

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -1,5 +1,7 @@
 export type AgentState =
   | 'registered'
+  | 'start'
+  | 'saved'
   | 'get_quote'
   | 'provide_v'
   | 'failed'


### PR DESCRIPTION
Show a descriptive error message when the agent list fails to load instead of silently showing an empty table. Add 'start' and 'saved' to the AgentState type to match real Keylime operational states.