### PR TITLE
Show consistent empty policy columns placeholder

### DIFF
--- a/src/pages/Agents/AgentList.tsx
+++ b/src/pages/Agents/AgentList.tsx
@@ -90,12 +90,17 @@ export function AgentList() {
       sortable: true,
       render: (row: AgentRow) => <StatusBadge label={row.state} />,
     },
-    { key: 'assigned_policy', header: 'IMA Policy', sortable: true },
+    {
+      key: 'assigned_policy',
+      header: 'IMA Policy',
+      sortable: true,
+      render: (row: AgentRow) => <span>{row.assigned_policy || '--'}</span>,
+    },
     {
       key: 'mb_policy',
       header: 'MB Policy',
       sortable: true,
-      render: (row: AgentRow) => <span>{row.mb_policy ?? '--'}</span>,
+      render: (row: AgentRow) => <span>{row.mb_policy || '--'}</span>,
     },
     {
       key: 'last_attestation',


### PR DESCRIPTION
Display '--' for both IMA Policy and MB Policy when the value is null or empty, using the same fallback pattern for both columns.