### PR TITLE
Rename IP Address column to IP:Port in agent list

### DIFF
--- a/src/pages/Agents/AgentList.tsx
+++ b/src/pages/Agents/AgentList.tsx
@@ -12,6 +12,7 @@ import type { AgentListParams } from '@/types';
 interface AgentRow {
   id: string;
   ip: string;
+  port: number | null;
   state: string;
   attestation_mode: string;
   last_attestation: string | null;
@@ -82,7 +83,14 @@ export function AgentList() {
         </Link>
       ),
     },
-    { key: 'ip', header: 'IP Address', sortable: true },
+    {
+      key: 'ip',
+      header: 'IP:Port',
+      sortable: true,
+      render: (row: AgentRow) => (
+        <span>{row.ip}{row.port ? `:${row.port}` : ''}</span>
+      ),
+    },
     { key: 'attestation_mode', header: 'Mode', sortable: true },
     {
       key: 'state',


### PR DESCRIPTION
Show port alongside IP in the agent list table when available. Gracefully falls back to IP-only display until the backend adds port to AgentSummary.