### PR TITLE
Fix IP:Port display when backend returns port 0

### DIFF
--- a/src/pages/Agents/AgentList.tsx
+++ b/src/pages/Agents/AgentList.tsx
@@ -88,7 +88,7 @@ export function AgentList() {
       header: 'IP:Port',
       sortable: true,
       render: (row: AgentRow) => (
-        <span>{row.ip}{row.port ? `:${row.port}` : ''}</span>
+        <span>{row.ip}{row.port != null && row.port > 0 ? `:${row.port}` : ''}</span>
       ),
     },
     { key: 'attestation_mode', header: 'Mode', sortable: true },


### PR DESCRIPTION
Use explicit null/zero check instead of truthy check so port 0 (push-mode agents without Registrar fallback) is handled correctly.