### PR TITLE
Remove agent-policy mapping

### DIFF
--- a/src/pages/Agents/AgentDetail.tsx
+++ b/src/pages/Agents/AgentDetail.tsx
@@ -11,8 +11,6 @@ interface AgentDetail {
   port: number;
   state: string;
   attestation_mode: string;
-  ima_policy: string | null;
-  mb_policy: string | null;
   [key: string]: unknown;
 }
 
@@ -71,7 +69,6 @@ export function AgentDetailPage() {
           </h1>
           <p className="page-header__subtitle">
             {agent.ip}:{agent.port} &middot; {agent.attestation_mode} mode
-            {agent.ima_policy && <> &middot; Policy: {agent.ima_policy}</>}
           </p>
         </div>
       </div>

--- a/src/pages/Agents/AgentList.tsx
+++ b/src/pages/Agents/AgentList.tsx
@@ -17,8 +17,6 @@ interface AgentRow {
   state: string;
   attestation_mode: string;
   last_attestation: string | null;
-  assigned_policy: string;
-  mb_policy: string | null;
   failure_count: number;
   [key: string]: unknown;
 }
@@ -31,7 +29,6 @@ export function AgentList() {
   const [page, setPage] = useState(1);
   const [stateFilter, setStateFilter] = useState<string>(searchParams.get('state') ?? '');
   const [modeFilter, setModeFilter] = useState<string>(searchParams.get('mode') ?? '');
-  const [policyFilter, setPolicyFilter] = useState<string>(searchParams.get('policy') ?? '');
   const [search, setSearch] = useState(searchParams.get('q') ?? '');
 
   // Sync search and state filter when URL query params change
@@ -39,11 +36,9 @@ export function AgentList() {
     const q = searchParams.get('q') ?? '';
     const state = searchParams.get('state') ?? '';
     const mode = searchParams.get('mode') ?? '';
-    const policy = searchParams.get('policy') ?? '';
     setSearch(q);
     setStateFilter(state);
     setModeFilter(mode);
-    setPolicyFilter(policy);
     setPage(1);
   }, [searchParams]);
 
@@ -70,7 +65,6 @@ export function AgentList() {
   const allItems: AgentRow[] = Array.isArray(rawItems) ? rawItems : [];
   let items = allItems;
   if (modeFilter) items = items.filter((a) => a.attestation_mode === modeFilter);
-  if (policyFilter) items = items.filter((a) => a.assigned_policy === policyFilter || a.mb_policy === policyFilter);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const totalPages = (data as any)?.total_pages ?? 1;
 
@@ -101,18 +95,6 @@ export function AgentList() {
       render: (row: AgentRow) => <StatusBadge label={row.state} />,
     },
     {
-      key: 'assigned_policy',
-      header: 'IMA Policy',
-      sortable: true,
-      render: (row: AgentRow) => <span>{row.assigned_policy || '--'}</span>,
-    },
-    {
-      key: 'mb_policy',
-      header: 'MB Policy',
-      sortable: true,
-      render: (row: AgentRow) => <span>{row.mb_policy || '--'}</span>,
-    },
-    {
       key: 'last_attestation',
       header: 'Last Attestation',
       sortable: true,
@@ -133,7 +115,6 @@ export function AgentList() {
             setSearch('');
             setStateFilter('');
             setModeFilter('');
-            setPolicyFilter('');
             setPage(1);
             setSearchParams({});
           }}

--- a/src/pages/Policies/Policies.tsx
+++ b/src/pages/Policies/Policies.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { DataTable } from '@/components/common/DataTable';
 import { StatusBadge } from '@/components/common/StatusBadge';
@@ -31,24 +30,6 @@ export function Policies() {
       render: (row: Policy) => (
         <StatusBadge label={KIND_LABELS[row.kind] ?? row.kind ?? '--'} variant="info" />
       ),
-    },
-    {
-      key: 'assigned_agents',
-      header: 'Agents',
-      sortable: true,
-      render: (row: Policy) => {
-        const count = row.assigned_agents ?? 0;
-        if (count === 0) return <span>0</span>;
-        return (
-          <Link
-            to={`/agents?policy=${encodeURIComponent(row.name)}`}
-            style={{ color: 'var(--color-primary)', fontWeight: 500 }}
-            title={`View agents with policy "${row.name}"`}
-          >
-            {count}
-          </Link>
-        );
-      },
     },
     { key: 'checksum', header: 'Checksum', render: (row: Policy) => (
       <span style={{ fontFamily: 'monospace', fontSize: '12px' }}>

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -24,8 +24,6 @@ export interface Agent {
   state: AgentState;
   verifier_id: string;
   registrar_id: string;
-  ima_policy: string;
-  mb_policy: string;
   last_attestation: string;
   consecutive_failures: number;
   registration_date: string;
@@ -41,7 +39,6 @@ export interface AgentListParams {
   state?: AgentState;
   search?: string;
   datacenter?: string;
-  policy?: string;
   ip_range?: string;
 }
 

--- a/src/types/policy.ts
+++ b/src/types/policy.ts
@@ -24,7 +24,6 @@ export interface Policy {
   content: string;
   checksum: string;
   hash_algorithm: HashAlgorithm;
-  assigned_agents: number;
   versions: PolicyVersion[];
   approval_state: ApprovalState;
   drafter: string;


### PR DESCRIPTION
Keylime v2 verifier does not expose which named policy is assigned to an agent, so the Agents column in Policies, the IMA/MB Policy columns in the Agent list, and the policy filter were always empty. Remove all related UI and types.