### PR TITLE
Fix Info KPI showing "--" in Alert Center

### DIFF
--- a/src/pages/Alerts/Alerts.tsx
+++ b/src/pages/Alerts/Alerts.tsx
@@ -157,7 +157,7 @@ export function Alerts() {
         />
         <KpiCard
           title="Info"
-          value={summary?.info ?? '--'}
+          value={summary?.info ?? alertItems.filter(a => a.severity === 'info').length}
           variant="info"
           onClick={() => { setSeverityFilter('info'); setStateFilter(''); }}
         />


### PR DESCRIPTION
The backend AlertSummary does not include an info field, so the KPI always fell back to "--". Compute the info count from the alert items when the summary does not provide it.