### PR TITLE
Add linkTo prop to KpiCard for SPA navigation

### DIFF
--- a/src/components/common/KpiCard.tsx
+++ b/src/components/common/KpiCard.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
 import './common.css';
 
 interface KpiCardProps {
@@ -8,24 +9,41 @@ interface KpiCardProps {
   variant?: 'default' | 'success' | 'warning' | 'danger' | 'info';
   icon?: ReactNode;
   onClick?: () => void;
+  linkTo?: string;
 }
 
-export function KpiCard({ title, value, subtitle, variant = 'default', icon, onClick }: KpiCardProps) {
-  return (
-    <div
-      className={`kpi-card kpi-card--${variant}`}
-      onClick={onClick}
-      style={onClick ? { cursor: 'pointer' } : undefined}
-      role={onClick ? 'button' : undefined}
-      tabIndex={onClick ? 0 : undefined}
-      onKeyDown={onClick ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick(); } } : undefined}
-    >
+export function KpiCard({ title, value, subtitle, variant = 'default', icon, onClick, linkTo }: KpiCardProps) {
+  const interactive = !!(linkTo || onClick);
+  const className = `kpi-card kpi-card--${variant}${interactive ? ' kpi-card--interactive' : ''}`;
+
+  const content = (
+    <>
       <div className="kpi-card__header">
         <span className="kpi-card__title">{title}</span>
         {icon && <span className="kpi-card__icon">{icon}</span>}
       </div>
       <div className="kpi-card__value">{value}</div>
       {subtitle && <div className="kpi-card__subtitle">{subtitle}</div>}
+    </>
+  );
+
+  if (linkTo) {
+    return (
+      <Link to={linkTo} className={className} aria-label={`${title}: ${value}`}>
+        {content}
+      </Link>
+    );
+  }
+
+  return (
+    <div
+      className={className}
+      onClick={onClick}
+      role={onClick ? 'button' : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onKeyDown={onClick ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick(); } } : undefined}
+    >
+      {content}
     </div>
   );
 }

--- a/src/components/common/common.css
+++ b/src/components/common/common.css
@@ -12,9 +12,24 @@
 .kpi-card--danger  { border-left: 4px solid var(--color-danger); }
 .kpi-card--info    { border-left: 4px solid var(--color-primary); }
 
-.kpi-card[role="button"]:hover {
+a.kpi-card {
+  text-decoration: none;
+  color: inherit;
+  display: block;
+}
+
+.kpi-card--interactive {
+  cursor: pointer;
+}
+
+.kpi-card--interactive:hover {
   box-shadow: var(--shadow-md, 0 2px 8px rgba(0,0,0,0.12));
   border-color: var(--color-primary);
+}
+
+.kpi-card--interactive:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }
 
 .kpi-card__header {

--- a/src/pages/Agents/AgentList.tsx
+++ b/src/pages/Agents/AgentList.tsx
@@ -43,6 +43,7 @@ export function AgentList() {
   }, [searchParams]);
 
   const isSearchMode = search.trim().length > 0;
+  const isMultiState = stateFilter.includes(',');
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['agents', page, stateFilter, modeFilter, search],
@@ -54,7 +55,7 @@ export function AgentList() {
       const res = await agentsApi.list({
         page,
         per_page: 25,
-        state: (stateFilter || undefined) as AgentListParams['state'],
+        state: (isMultiState ? undefined : stateFilter || undefined) as AgentListParams['state'],
       });
       return res.data;
     },
@@ -64,6 +65,10 @@ export function AgentList() {
   const rawItems = (data as any)?.items ?? data;
   const allItems: AgentRow[] = Array.isArray(rawItems) ? rawItems : [];
   let items = allItems;
+  if (isMultiState) {
+    const states = new Set(stateFilter.split(','));
+    items = items.filter((a) => states.has(a.state));
+  }
   if (modeFilter) items = items.filter((a) => a.attestation_mode === modeFilter);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const totalPages = (data as any)?.total_pages ?? 1;

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -146,6 +146,7 @@ export function Dashboard() {
           title="Total Agents"
           value={agents?.total_items ?? (agentItems.length || '--')}
           variant="default"
+          linkTo="/agents"
         />
         <KpiCard
           title="Attestation Success Rate"
@@ -157,12 +158,14 @@ export function Dashboard() {
                 : '--'
           }
           variant="success"
+          linkTo="/attestations"
         />
         <KpiCard
           title="Failed Attestations"
           value={attestationSummary?.total_failed ?? agentAttestation?.failedCount ?? '--'}
           variant="danger"
           subtitle={`in last ${timeRange}`}
+          linkTo="/agents?state=FAILED,INVALID_QUOTE,TENANT_FAILED,FAIL,TIMEOUT"
         />
         <KpiCard
           title="Active Alerts"
@@ -173,6 +176,7 @@ export function Dashboard() {
           }
           variant="warning"
           subtitle={`${alertSummary?.critical ?? 0} critical`}
+          linkTo="/alerts"
         />
       </div>
 

--- a/src/test/KpiCard.test.tsx
+++ b/src/test/KpiCard.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { KpiCard } from '@/components/common/KpiCard';
+
+function renderCard(props: React.ComponentProps<typeof KpiCard>) {
+  return render(
+    <MemoryRouter>
+      <KpiCard {...props} />
+    </MemoryRouter>
+  );
+}
+
+describe('KpiCard', () => {
+  it('renders as a plain div without linkTo or onClick', () => {
+    renderCard({ title: 'Agents', value: 42 });
+    const el = screen.getByText('42').closest('.kpi-card');
+    expect(el?.tagName).toBe('DIV');
+    expect(el).not.toHaveClass('kpi-card--interactive');
+  });
+
+  it('renders as a link when linkTo is set', () => {
+    renderCard({ title: 'Agents', value: 42, linkTo: '/agents' });
+    const link = screen.getByRole('link', { name: /Agents: 42/ });
+    expect(link).toHaveAttribute('href', '/agents');
+    expect(link).toHaveClass('kpi-card--interactive');
+  });
+
+  it('navigates to the correct route with query params', () => {
+    renderCard({ title: 'Failed', value: 3, linkTo: '/agents?state=FAILED,FAIL' });
+    const link = screen.getByRole('link', { name: /Failed: 3/ });
+    expect(link).toHaveAttribute('href', '/agents?state=FAILED,FAIL');
+  });
+
+  it('calls onClick when clicked without linkTo', () => {
+    const handler = vi.fn();
+    renderCard({ title: 'Alerts', value: 5, onClick: handler });
+    const el = screen.getByRole('button');
+    fireEvent.click(el);
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it('supports keyboard activation for onClick cards', () => {
+    const handler = vi.fn();
+    renderCard({ title: 'Alerts', value: 5, onClick: handler });
+    const el = screen.getByRole('button');
+    fireEvent.keyDown(el, { key: 'Enter' });
+    fireEvent.keyDown(el, { key: ' ' });
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
+  it('preserves variant styling on link cards', () => {
+    renderCard({ title: 'Rate', value: '99%', variant: 'success', linkTo: '/attestations' });
+    const link = screen.getByRole('link');
+    expect(link).toHaveClass('kpi-card--success');
+  });
+});


### PR DESCRIPTION
Resolves: #79

- Add optional linkTo prop that renders the card as a React Router Link for client-side navigation without full page reloads
- Wire Dashboard KPI cards to /agents, /attestations, /agents?state=..., and /alerts routes
- Add KpiCard unit tests covering link rendering, onClick fallback, keyboard activation, and variant preservation