### PR TITLE
Fix Info KPI changing when table filters are applied

### DIFF
--- a/src/pages/Alerts/Alerts.tsx
+++ b/src/pages/Alerts/Alerts.tsx
@@ -284,7 +284,7 @@ export function Alerts() {
         />
         <KpiCard
           title="Info"
-          value={summary?.info ?? alertItems.filter(a => a.severity === 'info').length}
+          value={summary?.info ?? '--'}
           variant="info"
           onClick={() => { setSeverityFilter('info'); setStateFilter(''); }}
         />

--- a/src/types/alert.ts
+++ b/src/types/alert.ts
@@ -39,6 +39,6 @@ export interface Alert {
 export interface AlertSummary {
   critical: number;
   warnings: number;
-  info?: number;
+  info: number;
   resolved_24h: number;
 }


### PR DESCRIPTION
Make AlertSummary.info required and use the summary endpoint value instead of falling back to the filtered alert list, matching the pattern used by the other three KPI cards.