### PR TITLE
Use dedicated active_alerts fields for Dashboard KPI

### DIFF
--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -169,13 +169,9 @@ export function Dashboard() {
         />
         <KpiCard
           title="Active Alerts"
-          value={
-            alertSummary?.critical != null && alertSummary?.warnings != null
-              ? alertSummary.critical + alertSummary.warnings
-              : '--'
-          }
+          value={alertSummary?.active_alerts ?? '--'}
           variant="warning"
-          subtitle={`${alertSummary?.critical ?? 0} critical`}
+          subtitle={`${alertSummary?.active_critical ?? 0} critical`}
           linkTo="/alerts"
         />
       </div>

--- a/src/types/alert.ts
+++ b/src/types/alert.ts
@@ -41,4 +41,6 @@ export interface AlertSummary {
   warnings: number;
   info: number;
   resolved_24h: number;
+  active_alerts: number;
+  active_critical: number;
 }


### PR DESCRIPTION
The backend now returns active_alerts and active_critical in the summary endpoint, counting only non-terminal alerts. Use these instead of computing critical + warnings client-side.