### PR TITLE
Remove Resolved KPI card from Alert Center

### DIFF
--- a/src/pages/Alerts/Alerts.tsx
+++ b/src/pages/Alerts/Alerts.tsx
@@ -288,12 +288,6 @@ export function Alerts() {
           variant="info"
           onClick={() => { setSeverityFilter('info'); setStateFilter(''); }}
         />
-        <KpiCard
-          title="Resolved"
-          value={summary?.resolved_24h ?? '--'}
-          variant="success"
-          onClick={() => { setStateFilter('resolved'); setSeverityFilter(''); }}
-        />
       </div>
 
       <div className="section" style={{ display: 'flex', gap: '12px', padding: '12px 20px' }}>

--- a/src/types/alert.ts
+++ b/src/types/alert.ts
@@ -40,7 +40,6 @@ export interface AlertSummary {
   critical: number;
   warnings: number;
   info: number;
-  resolved_24h: number;
   active_alerts: number;
   active_critical: number;
 }


### PR DESCRIPTION
The Resolved card is no longer needed; only the three severity-based KPI cards (Critical, Warnings, Info) remain. The resolved_24h field is also removed from the AlertSummary type as it has no consumers.