### PR TITLE
Implement certificate management views

### DIFF
--- a/src/api/agents.ts
+++ b/src/api/agents.ts
@@ -1,5 +1,5 @@
 import apiClient from './client';
-import type { Agent, AgentListParams, ImaLogEntry, BootLogEntry, PaginatedResponse } from '@/types';
+import type { Agent, AgentListParams, Certificate, ImaLogEntry, BootLogEntry, PaginatedResponse } from '@/types';
 import type { AttestationTimelinePoint } from '@/types';
 
 export const agentsApi = {
@@ -36,7 +36,7 @@ export const agentsApi = {
   },
 
   certificates(agentId: string) {
-    return apiClient.get(`/agents/${agentId}/certificates`);
+    return apiClient.get<Certificate[]>(`/agents/${agentId}/certificates`);
   },
 
   raw(agentId: string, source?: 'backend' | 'registrar' | 'verifier') {

--- a/src/api/certificates.ts
+++ b/src/api/certificates.ts
@@ -1,8 +1,8 @@
 import apiClient from './client';
-import type { Certificate, CertificateExpirySummary, PaginatedResponse } from '@/types';
+import type { Certificate, CertificateExpirySummary, CertificateTimelineEntry, CertificateType, ExpiryCategory, PaginatedResponse } from '@/types';
 
 export const certificatesApi = {
-  list(params?: { type?: string; expiry_category?: string }) {
+  list(params?: { type?: CertificateType; expiry_category?: ExpiryCategory }) {
     return apiClient.get<PaginatedResponse<Certificate>>('/certificates', { params });
   },
 
@@ -14,15 +14,19 @@ export const certificatesApi = {
     return apiClient.get<Certificate>(`/certificates/${certId}`);
   },
 
-  renew(certId: string) {
-    return apiClient.post(`/certificates/${certId}/renew`);
-  },
-
-  batchRenew(certIds: string[]) {
-    return apiClient.post('/certificates/batch-renew', { cert_ids: certIds });
-  },
-
   timeline() {
-    return apiClient.get('/certificates/timeline');
+    return apiClient.get<CertificateTimelineEntry[]>('/certificates/timeline');
+  },
+
+  downloadPem(certId: string) {
+    return apiClient.get<Blob>(`/certificates/${certId}/download/pem`, {
+      responseType: 'blob',
+    });
+  },
+
+  downloadDer(certId: string) {
+    return apiClient.get<Blob>(`/certificates/${certId}/download/der`, {
+      responseType: 'blob',
+    });
   },
 };

--- a/src/components/common/StatusBadge.tsx
+++ b/src/components/common/StatusBadge.tsx
@@ -29,6 +29,11 @@ const VARIANT_MAP: Record<string, BadgeVariant> = {
   // Push-mode agent states
   pending: 'warning',
   timeout: 'danger',
+  // Certificate expiry categories
+  warning_90d: 'info',
+  warning_30d: 'warning',
+  critical_7d: 'danger',
+  critical_1d: 'danger',
   // Generic
   pass: 'success',
   fail: 'danger',

--- a/src/components/common/common.css
+++ b/src/components/common/common.css
@@ -283,3 +283,179 @@ a.kpi-card {
   font-size: 14px;
   max-width: 400px;
 }
+
+/* Certificate Detail */
+.cert-detail__grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+@media (max-width: 700px) {
+  .cert-detail__grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.cert-detail__field {
+  margin-bottom: 12px;
+}
+
+.cert-detail__label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 4px;
+}
+
+.cert-detail__value {
+  font-size: 14px;
+  color: var(--color-text);
+  word-break: break-all;
+}
+
+.cert-detail__value--mono {
+  font-family: monospace;
+  font-size: 13px;
+}
+
+.cert-detail__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+/* Certificate Chain */
+.cert-chain {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.cert-chain__item {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 12px 16px;
+  position: relative;
+}
+
+.cert-chain__item--valid {
+  border-left: 4px solid var(--color-success);
+}
+
+.cert-chain__item--invalid {
+  border-left: 4px solid var(--color-danger);
+}
+
+.cert-chain__connector {
+  width: 2px;
+  height: 20px;
+  background: var(--color-border);
+  margin-left: 24px;
+}
+
+/* Certificate Card (agent detail tab) */
+.cert-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 16px;
+  cursor: pointer;
+  transition: box-shadow 0.15s, border-color 0.15s;
+}
+
+.cert-card:hover {
+  box-shadow: var(--shadow-md, 0 2px 8px rgba(0,0,0,0.12));
+  border-color: var(--color-primary);
+}
+
+.cert-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.cert-card__countdown {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.cert-card__countdown--ok {
+  color: var(--color-success);
+}
+
+.cert-card__countdown--warning {
+  color: var(--color-warning);
+}
+
+.cert-card__countdown--critical {
+  color: #e8710a;
+}
+
+.cert-card__countdown--danger {
+  color: var(--color-danger);
+}
+
+/* Filter bar */
+.filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.filter-bar__group {
+  display: inline-flex;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.filter-bar__btn {
+  padding: 6px 14px;
+  font-size: 12px;
+  font-weight: 500;
+  border: none;
+  background: var(--color-surface);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.filter-bar__btn + .filter-bar__btn {
+  border-left: 1px solid var(--color-border);
+}
+
+.filter-bar__btn--active {
+  background: var(--color-primary);
+  color: white;
+  font-weight: 600;
+}
+
+/* Timeline Legend */
+.timeline-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 12px;
+  font-size: 12px;
+  color: var(--color-text-secondary);
+}
+
+.timeline-legend__item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.timeline-legend__swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+}

--- a/src/pages/Agents/AgentDetail.tsx
+++ b/src/pages/Agents/AgentDetail.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { StatusBadge } from '@/components/common/StatusBadge';
 import { useFormatTimestamp } from '@/store/visualizationStore';
 import { agentsApi } from '@/api/agents';
+import type { Certificate, CertificateType } from '@/types';
 
 interface AgentDetail {
   id: string;
@@ -347,24 +348,99 @@ function BootLogTab({ agentId }: { agentId: string }) {
   );
 }
 
+const CERT_TYPE_LABELS: Record<CertificateType, string> = {
+  ek: 'EK Certificate',
+  ak: 'AK Certificate',
+  mtls: 'mTLS Certificate',
+};
+
+const CERT_DISPLAY_ORDER: CertificateType[] = ['ek', 'ak', 'mtls'];
+
+function daysRemaining(notAfter: string): number {
+  const diff = new Date(notAfter).getTime() - Date.now();
+  return Math.max(0, Math.ceil(diff / (1000 * 60 * 60 * 24)));
+}
+
+function countdownClass(days: number): string {
+  if (days <= 1) return 'cert-card__countdown--danger';
+  if (days <= 7) return 'cert-card__countdown--critical';
+  if (days <= 30) return 'cert-card__countdown--warning';
+  return 'cert-card__countdown--ok';
+}
+
 function CertsTab({ agentId }: { agentId: string }) {
+  const fmtTs = useFormatTimestamp();
+
   const { data } = useQuery({
     queryKey: ['agent', agentId, 'certs'],
     queryFn: () => agentsApi.certificates(agentId),
     select: (res) => res.data,
   });
 
-  void data;
+  const certs: Certificate[] = Array.isArray(data) ? (data as Certificate[]) : [];
+
+  const grouped = certs.reduce<Record<string, Certificate[]>>((acc, cert) => {
+    (acc[cert.type] ??= []).push(cert);
+    return acc;
+  }, {});
+
+  if (certs.length === 0) {
+    return (
+      <div>
+        <h3 className="section__title">Certificates</h3>
+        <div className="placeholder">
+          <div className="placeholder__icon">&#x1F512;</div>
+          <div className="placeholder__text">No certificates found</div>
+          <div className="placeholder__subtext">
+            EK, AK, and mTLS certificates will appear here when available.
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div>
       <h3 className="section__title">Certificates</h3>
-      <div className="placeholder">
-        <div className="placeholder__icon">&#x1F512;</div>
-        <div className="placeholder__text">Agent certificates</div>
-        <div className="placeholder__subtext">
-          EK, AK, IAK, IDevID, and mTLS certificates with expiry countdowns.
-        </div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: '16px' }}>
+        {CERT_DISPLAY_ORDER.map((type) => {
+          const typeCerts = grouped[type];
+          if (!typeCerts?.length) return null;
+          return typeCerts.map((cert) => {
+            const days = daysRemaining(cert.not_after);
+            return (
+              <Link
+                key={cert.id}
+                to={`/certificates/${cert.id}`}
+                className="cert-card"
+                style={{ textDecoration: 'none', color: 'inherit' }}
+                aria-label={`${CERT_TYPE_LABELS[type]} - ${days} days remaining`}
+              >
+                <div className="cert-card__header">
+                  <StatusBadge label={cert.type.toUpperCase()} variant="info" />
+                  <StatusBadge label={cert.expiry_category} />
+                </div>
+                <div style={{ fontSize: '14px', fontWeight: 500, color: 'var(--color-text)', marginBottom: '4px' }}>
+                  {CERT_TYPE_LABELS[type]}
+                </div>
+                <div style={{ fontSize: '12px', color: 'var(--color-text-secondary)', fontFamily: 'monospace', marginBottom: '4px' }}>
+                  {cert.subject_dn}
+                </div>
+                <div style={{ fontSize: '12px', color: 'var(--color-text-secondary)', marginBottom: '8px' }}>
+                  Issuer: {cert.issuer_dn}
+                </div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                  <span style={{ fontSize: '12px', color: 'var(--color-text-secondary)' }}>
+                    Expires: {fmtTs(cert.not_after)}
+                  </span>
+                  <span className={`cert-card__countdown ${countdownClass(days)}`}>
+                    {days === 0 ? 'Expired' : `${days}d remaining`}
+                  </span>
+                </div>
+              </Link>
+            );
+          });
+        })}
       </div>
     </div>
   );

--- a/src/pages/Certificates/CertificateDetail.tsx
+++ b/src/pages/Certificates/CertificateDetail.tsx
@@ -1,0 +1,254 @@
+import { useParams, useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { StatusBadge } from '@/components/common/StatusBadge';
+import { useFormatTimestamp } from '@/store/visualizationStore';
+import { certificatesApi } from '@/api/certificates';
+import type { Certificate } from '@/types';
+
+const TYPE_LABELS: Record<string, string> = {
+  ek: 'EK Certificate',
+  ak: 'AK Certificate',
+  mtls: 'mTLS Certificate',
+};
+
+function triggerDownload(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export function CertificateDetail() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const fmtTs = useFormatTimestamp();
+
+  const { data: cert, isLoading } = useQuery({
+    queryKey: ['certificates', 'detail', id],
+    queryFn: () => certificatesApi.get(id!),
+    select: (res) => res.data as Certificate,
+    enabled: !!id,
+  });
+
+  const handleDownload = async (format: 'pem' | 'der') => {
+    if (!id) return;
+    const response = format === 'pem'
+      ? await certificatesApi.downloadPem(id)
+      : await certificatesApi.downloadDer(id);
+    const blob = response.data as Blob;
+    triggerDownload(blob, `${cert?.serial_number ?? id}.${format}`);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="placeholder">
+        <div className="placeholder__text">Loading certificate details...</div>
+      </div>
+    );
+  }
+
+  if (!cert) {
+    return (
+      <div className="placeholder">
+        <div className="placeholder__text">Certificate not found</div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="page-header" style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
+        <button
+          onClick={() => navigate('/certificates')}
+          style={{
+            background: 'none',
+            border: '1px solid var(--color-border)',
+            borderRadius: 'var(--radius-sm)',
+            padding: '6px 12px',
+            fontSize: '14px',
+            color: 'var(--color-text)',
+            cursor: 'pointer',
+          }}
+          aria-label="Back to certificates list"
+        >
+          &larr; Back
+        </button>
+        <div>
+          <h1 className="page-header__title" style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
+            <span>{TYPE_LABELS[cert.type] ?? cert.type.toUpperCase()}</span>
+            <StatusBadge label={cert.type.toUpperCase()} variant="info" />
+            <StatusBadge label={cert.validation_status} />
+          </h1>
+          <p className="page-header__subtitle">{cert.subject_dn}</p>
+        </div>
+      </div>
+
+      <div className="section">
+        <h2 className="section__title">Certificate Details</h2>
+        <div className="cert-detail__grid">
+          <div>
+            <div className="cert-detail__field">
+              <div className="cert-detail__label">Subject DN</div>
+              <div className="cert-detail__value cert-detail__value--mono">{cert.subject_dn}</div>
+            </div>
+            <div className="cert-detail__field">
+              <div className="cert-detail__label">Issuer DN</div>
+              <div className="cert-detail__value cert-detail__value--mono">{cert.issuer_dn}</div>
+            </div>
+            <div className="cert-detail__field">
+              <div className="cert-detail__label">Serial Number</div>
+              <div className="cert-detail__value cert-detail__value--mono">{cert.serial_number}</div>
+            </div>
+            <div className="cert-detail__field">
+              <div className="cert-detail__label">Validity Period</div>
+              <div className="cert-detail__value">
+                {fmtTs(cert.not_before)} &mdash; {fmtTs(cert.not_after)}
+              </div>
+            </div>
+            <div className="cert-detail__field">
+              <div className="cert-detail__label">Expiry Status</div>
+              <div className="cert-detail__value">
+                <StatusBadge label={cert.expiry_category} />
+              </div>
+            </div>
+          </div>
+          <div>
+            <div className="cert-detail__field">
+              <div className="cert-detail__label">Public Key Algorithm</div>
+              <div className="cert-detail__value">{cert.public_key_algorithm}</div>
+            </div>
+            <div className="cert-detail__field">
+              <div className="cert-detail__label">Public Key Size</div>
+              <div className="cert-detail__value">{cert.public_key_size} bits</div>
+            </div>
+            <div className="cert-detail__field">
+              <div className="cert-detail__label">Signature Algorithm</div>
+              <div className="cert-detail__value">{cert.signature_algorithm}</div>
+            </div>
+            <div className="cert-detail__field">
+              <div className="cert-detail__label">Agent</div>
+              <div className="cert-detail__value cert-detail__value--mono">{cert.associated_entity}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {cert.san.length > 0 && (
+        <div className="section">
+          <h2 className="section__title">Subject Alternative Names</h2>
+          <div className="cert-detail__tags">
+            {cert.san.map((s) => (
+              <StatusBadge key={s} label={s} variant="neutral" />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {cert.key_usage.length > 0 && (
+        <div className="section">
+          <h2 className="section__title">Key Usage</h2>
+          <div className="cert-detail__tags">
+            {cert.key_usage.map((ku) => (
+              <StatusBadge key={ku} label={ku} variant="info" />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {cert.extended_key_usage.length > 0 && (
+        <div className="section">
+          <h2 className="section__title">Extended Key Usage</h2>
+          <div className="cert-detail__tags">
+            {cert.extended_key_usage.map((eku) => (
+              <StatusBadge key={eku} label={eku} variant="info" />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {cert.chain.length > 0 && (
+        <div className="section">
+          <h2 className="section__title" style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+            Certificate Chain
+            {cert.chain_valid !== null && (
+              <StatusBadge
+                label={cert.chain_valid ? 'chain valid' : 'chain invalid'}
+                variant={cert.chain_valid ? 'success' : 'danger'}
+              />
+            )}
+          </h2>
+          <div className="cert-chain">
+            <div className={`cert-chain__item cert-chain__item--${cert.validation_status === 'valid' ? 'valid' : 'invalid'}`}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '4px' }}>
+                <strong style={{ fontSize: '13px', color: 'var(--color-text)' }}>Leaf Certificate</strong>
+                <StatusBadge label={cert.validation_status} />
+              </div>
+              <div style={{ fontSize: '12px', color: 'var(--color-text-secondary)', fontFamily: 'monospace' }}>
+                {cert.subject_dn}
+              </div>
+            </div>
+            {cert.chain.map((chainCert, idx) => (
+              <div key={chainCert.id ?? idx}>
+                <div className="cert-chain__connector" />
+                <div className={`cert-chain__item cert-chain__item--${chainCert.validation_status === 'valid' ? 'valid' : 'invalid'}`}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '4px' }}>
+                    <strong style={{ fontSize: '13px', color: 'var(--color-text)' }}>
+                      {idx === cert.chain.length - 1 ? 'Root CA' : `Intermediate CA ${idx + 1}`}
+                    </strong>
+                    <StatusBadge label={chainCert.validation_status} />
+                  </div>
+                  <div style={{ fontSize: '12px', color: 'var(--color-text-secondary)', fontFamily: 'monospace' }}>
+                    {chainCert.subject_dn}
+                  </div>
+                  <div style={{ fontSize: '11px', color: 'var(--color-text-secondary)', marginTop: '4px' }}>
+                    Issuer: {chainCert.issuer_dn}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="section">
+        <h2 className="section__title">Export Certificate</h2>
+        <div style={{ display: 'flex', gap: '12px' }}>
+          <button
+            onClick={() => handleDownload('pem')}
+            aria-label="Download certificate in PEM format"
+            style={{
+              padding: '8px 20px',
+              fontSize: '14px',
+              fontWeight: 500,
+              border: '1px solid var(--color-border)',
+              borderRadius: 'var(--radius-sm)',
+              background: 'var(--color-surface)',
+              color: 'var(--color-text)',
+              cursor: 'pointer',
+            }}
+          >
+            Download PEM
+          </button>
+          <button
+            onClick={() => handleDownload('der')}
+            aria-label="Download certificate in DER format"
+            style={{
+              padding: '8px 20px',
+              fontSize: '14px',
+              fontWeight: 500,
+              border: '1px solid var(--color-border)',
+              borderRadius: 'var(--radius-sm)',
+              background: 'var(--color-surface)',
+              color: 'var(--color-text)',
+              cursor: 'pointer',
+            }}
+          >
+            Download DER
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Certificates/Certificates.tsx
+++ b/src/pages/Certificates/Certificates.tsx
@@ -1,11 +1,44 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell } from 'recharts';
 import { KpiCard } from '@/components/common/KpiCard';
 import { DataTable } from '@/components/common/DataTable';
 import { StatusBadge } from '@/components/common/StatusBadge';
+import { useFormatTimestamp } from '@/store/visualizationStore';
 import { certificatesApi } from '@/api/certificates';
-import type { Certificate } from '@/types';
+import type { Certificate, CertificateType, ExpiryCategory } from '@/types';
+
+const TYPE_FILTERS: Array<{ label: string; value: CertificateType | '' }> = [
+  { label: 'All', value: '' },
+  { label: 'EK', value: 'ek' },
+  { label: 'AK', value: 'ak' },
+  { label: 'mTLS', value: 'mtls' },
+];
+
+const EXPIRY_COLORS: Record<ExpiryCategory, string> = {
+  valid: '#34a853',
+  warning_90d: '#4285f4',
+  warning_30d: '#f9ab00',
+  critical_7d: '#e8710a',
+  critical_1d: '#ea4335',
+  expired: '#991b1b',
+};
+
+const EXPIRY_LABELS: Record<ExpiryCategory, string> = {
+  valid: 'Valid (>90d)',
+  warning_90d: 'Info (90d)',
+  warning_30d: 'Action (30d)',
+  critical_7d: 'Critical (7d)',
+  critical_1d: 'Emergency (1d)',
+  expired: 'Expired',
+};
 
 export function Certificates() {
+  const navigate = useNavigate();
+  const fmtTs = useFormatTimestamp();
+  const [typeFilter, setTypeFilter] = useState<CertificateType | ''>('');
+
   const { data: summary } = useQuery({
     queryKey: ['certificates', 'expiry-summary'],
     queryFn: () => certificatesApi.expirySummary(),
@@ -13,13 +46,21 @@ export function Certificates() {
   });
 
   const { data: certs, isLoading } = useQuery({
-    queryKey: ['certificates', 'list'],
-    queryFn: () => certificatesApi.list(),
+    queryKey: ['certificates', 'list', typeFilter],
+    queryFn: () => certificatesApi.list(typeFilter ? { type: typeFilter } : undefined),
     select: (res) => res.data,
   });
 
+  const { data: timeline } = useQuery({
+    queryKey: ['certificates', 'timeline'],
+    queryFn: () => certificatesApi.timeline(),
+    select: (res) => res.data,
+  });
+
+  const timelineData = Array.isArray(timeline) ? timeline : [];
+
   const columns = [
-    { key: 'associated_entity', header: 'Entity', sortable: true },
+    { key: 'associated_entity', header: 'Agent ID', sortable: true },
     {
       key: 'type',
       header: 'Type',
@@ -28,8 +69,7 @@ export function Certificates() {
         <StatusBadge label={row.type?.toUpperCase() ?? '--'} variant="info" />
       ),
     },
-    { key: 'subject_dn', header: 'Subject DN', sortable: true },
-    { key: 'not_after', header: 'Expires', sortable: true },
+    { key: 'issuer_dn', header: 'Issuer', sortable: true },
     {
       key: 'expiry_category',
       header: 'Status',
@@ -37,24 +77,18 @@ export function Certificates() {
       render: (row: Certificate) => <StatusBadge label={row.expiry_category ?? 'unknown'} />,
     },
     {
-      key: 'actions',
-      header: 'Actions',
-      render: () => (
-        <button
-          style={{
-            padding: '4px 12px',
-            fontSize: '12px',
-            border: '1px solid var(--color-border)',
-            borderRadius: 'var(--radius-sm)',
-            background: 'var(--color-surface)',
-            color: 'var(--color-text)',
-          }}
-        >
-          View
-        </button>
+      key: 'not_after',
+      header: 'Expiry Date',
+      sortable: true,
+      render: (row: Certificate) => (
+        <span style={{ fontFamily: 'monospace', fontSize: '13px' }}>
+          {row.not_after ? fmtTs(row.not_after) : '--'}
+        </span>
       ),
     },
   ];
+
+  const certRows = Array.isArray(certs?.items) ? certs.items : Array.isArray(certs) ? certs : [];
 
   return (
     <div>
@@ -66,18 +100,78 @@ export function Certificates() {
       <div className="kpi-grid">
         <KpiCard title="Expired" value={summary?.expired ?? '--'} variant="danger" />
         <KpiCard title="Expiring < 30d" value={summary?.expiring_30d ?? '--'} variant="warning" />
+        <KpiCard title="Expiring < 90d" value={summary?.expiring_90d ?? '--'} variant="info" />
         <KpiCard title="Valid" value={summary?.valid ?? '--'} variant="success" />
         <KpiCard title="Total" value={summary?.total ?? '--'} />
       </div>
 
       <div className="section">
         <h2 className="section__title">90-Day Expiry Timeline</h2>
-        <div className="placeholder">
-          <div className="placeholder__icon">&#x1F4C5;</div>
-          <div className="placeholder__text">Expiry forecast timeline</div>
-          <div className="placeholder__subtext">
-            Certificate expirations plotted on a 90-day timeline with tiered severity coloring.
+        {timelineData.length > 0 ? (
+          <>
+            <ResponsiveContainer width="100%" height={280}>
+              <BarChart data={timelineData}>
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+                <XAxis dataKey="date" fontSize={11} tick={{ fill: 'var(--color-text-secondary)' }} />
+                <YAxis fontSize={11} tick={{ fill: 'var(--color-text-secondary)' }} allowDecimals={false} />
+                <Tooltip
+                  contentStyle={{
+                    background: 'var(--color-surface)',
+                    border: '1px solid var(--color-border)',
+                    borderRadius: 'var(--radius-sm)',
+                    color: 'var(--color-text)',
+                  }}
+                  formatter={(value: number, _name: string, props: { payload?: { expiry_category?: ExpiryCategory } }) => [
+                    value,
+                    EXPIRY_LABELS[props.payload?.expiry_category as ExpiryCategory] ?? props.payload?.expiry_category ?? '',
+                  ]}
+                />
+                <Bar dataKey="count" name="Certificates" radius={[2, 2, 0, 0]}>
+                  {timelineData.map((entry, index) => (
+                    <Cell key={index} fill={EXPIRY_COLORS[entry.expiry_category] ?? '#6b7280'} />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+            <div className="timeline-legend" role="list" aria-label="Timeline color legend">
+              {(Object.keys(EXPIRY_COLORS) as ExpiryCategory[]).map((cat) => (
+                <div key={cat} className="timeline-legend__item" role="listitem">
+                  <span
+                    className="timeline-legend__swatch"
+                    style={{ background: EXPIRY_COLORS[cat] }}
+                    aria-hidden="true"
+                  />
+                  <span>{EXPIRY_LABELS[cat]}</span>
+                </div>
+              ))}
+            </div>
+          </>
+        ) : (
+          <div className="placeholder">
+            <div className="placeholder__icon">&#x1F4C5;</div>
+            <div className="placeholder__text">No timeline data available</div>
+            <div className="placeholder__subtext">
+              Certificate expirations will be plotted on a 90-day timeline once data is available.
+            </div>
           </div>
+        )}
+      </div>
+
+      <div className="filter-bar">
+        <span style={{ fontSize: '13px', fontWeight: 500, color: 'var(--color-text-secondary)' }}>
+          Filter by type:
+        </span>
+        <div className="filter-bar__group" role="group" aria-label="Certificate type filter">
+          {TYPE_FILTERS.map((f) => (
+            <button
+              key={f.value}
+              className={`filter-bar__btn${typeFilter === f.value ? ' filter-bar__btn--active' : ''}`}
+              onClick={() => setTypeFilter(f.value)}
+              aria-pressed={typeFilter === f.value}
+            >
+              {f.label}
+            </button>
+          ))}
         </div>
       </div>
 
@@ -88,9 +182,9 @@ export function Certificates() {
       ) : (
         <DataTable<Certificate>
           columns={columns}
-          data={Array.isArray(certs?.items) ? certs.items : Array.isArray(certs) ? certs : []}
+          data={certRows}
           keyField="id"
-          selectable
+          onRowClick={(row) => navigate(`/certificates/${row.id}`)}
         />
       )}
     </div>

--- a/src/pages/Certificates/Certificates.tsx
+++ b/src/pages/Certificates/Certificates.tsx
@@ -121,10 +121,10 @@ export function Certificates() {
                     borderRadius: 'var(--radius-sm)',
                     color: 'var(--color-text)',
                   }}
-                  formatter={(value: number, _name: string, props: { payload?: { expiry_category?: ExpiryCategory } }) => [
-                    value,
-                    EXPIRY_LABELS[props.payload?.expiry_category as ExpiryCategory] ?? props.payload?.expiry_category ?? '',
-                  ]}
+                  formatter={(value, _name, item) => {
+                    const cat = (item.payload as Record<string, unknown>)?.expiry_category as ExpiryCategory | undefined;
+                    return [String(value), EXPIRY_LABELS[cat!] ?? cat ?? ''];
+                  }}
                 />
                 <Bar dataKey="count" name="Certificates" radius={[2, 2, 0, 0]}>
                   {timelineData.map((entry, index) => (

--- a/src/pages/Certificates/__tests__/CertificateDetail.test.tsx
+++ b/src/pages/Certificates/__tests__/CertificateDetail.test.tsx
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { CertificateDetail } from '../CertificateDetail';
+import type { Certificate } from '@/types';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const mockEkCert: Certificate = {
+  id: 'cert-ek-1',
+  type: 'ek',
+  subject_dn: 'CN=TPM-EK,O=Vendor',
+  issuer_dn: 'CN=TPM-Vendor-CA',
+  serial_number: 'AA:BB:CC:DD',
+  not_before: '2025-01-01T00:00:00Z',
+  not_after: '2026-12-31T00:00:00Z',
+  public_key_algorithm: 'RSA',
+  public_key_size: 2048,
+  signature_algorithm: 'SHA256withRSA',
+  san: ['dns:tpm.example.com', 'ip:192.168.1.1'],
+  key_usage: ['digitalSignature', 'keyEncipherment'],
+  extended_key_usage: ['serverAuth'],
+  status: 'valid',
+  associated_entity: 'agent-001',
+  validation_status: 'valid',
+  chain_valid: true,
+  chain: [
+    {
+      id: 'cert-ca-1',
+      type: 'ek',
+      subject_dn: 'CN=Root-CA',
+      issuer_dn: 'CN=Root-CA',
+      serial_number: '11:22:33',
+      not_before: '2020-01-01T00:00:00Z',
+      not_after: '2030-12-31T00:00:00Z',
+      public_key_algorithm: 'RSA',
+      public_key_size: 4096,
+      signature_algorithm: 'SHA256withRSA',
+      san: [],
+      key_usage: [],
+      extended_key_usage: [],
+      status: 'valid',
+      associated_entity: '',
+      validation_status: 'valid',
+      chain_valid: null,
+      chain: [],
+      expiry_category: 'valid',
+    },
+  ],
+  expiry_category: 'valid',
+};
+
+const mockMtlsCert: Certificate = {
+  ...mockEkCert,
+  id: 'cert-mtls-1',
+  type: 'mtls',
+  subject_dn: 'CN=agent-mtls',
+  chain: [],
+  san: [],
+  key_usage: [],
+  extended_key_usage: [],
+};
+
+let currentCert: Certificate = mockEkCert;
+
+vi.mock('@/api/certificates', () => ({
+  certificatesApi: {
+    get: vi.fn().mockImplementation(() =>
+      Promise.resolve({ data: currentCert }),
+    ),
+    downloadPem: vi.fn().mockResolvedValue({
+      data: new Blob(['-----BEGIN CERTIFICATE-----'], { type: 'application/x-pem-file' }),
+    }),
+    downloadDer: vi.fn().mockResolvedValue({
+      data: new Blob([new Uint8Array([0x30])], { type: 'application/x-x509-ca-cert' }),
+    }),
+  },
+}));
+
+vi.mock('@/api/client', () => ({
+  default: { get: vi.fn() },
+  getBackendUrl: () => 'http://localhost:8080',
+}));
+
+function renderWithProviders(certId: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[`/certificates/${certId}`]}>
+        <Routes>
+          <Route path="/certificates/:id" element={<CertificateDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockNavigate.mockClear();
+  currentCert = mockEkCert;
+});
+
+describe('CertificateDetail page', () => {
+  it('renders certificate detail fields', async () => {
+    renderWithProviders('cert-ek-1');
+    expect(await screen.findByText('Certificate Details')).toBeInTheDocument();
+    expect(screen.getByText('AA:BB:CC:DD')).toBeInTheDocument();
+    expect(screen.getByText('2048 bits')).toBeInTheDocument();
+    const subjectDns = screen.getAllByText('CN=TPM-EK,O=Vendor');
+    expect(subjectDns.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('shows certificate chain with chain_valid badge', async () => {
+    renderWithProviders('cert-ek-1');
+    expect(await screen.findByText('Certificate Chain')).toBeInTheDocument();
+    expect(screen.getByText('Leaf Certificate')).toBeInTheDocument();
+    expect(screen.getByText('Root CA')).toBeInTheDocument();
+    expect(screen.getByText('CN=Root-CA')).toBeInTheDocument();
+    expect(screen.getByText('chain valid')).toBeInTheDocument();
+  });
+
+  it('hides chain section for non-EK certs', async () => {
+    currentCert = mockMtlsCert;
+    renderWithProviders('cert-mtls-1');
+    await screen.findByText('Certificate Details');
+    expect(screen.queryByText('Certificate Chain')).not.toBeInTheDocument();
+  });
+
+  it('shows SANs when present', async () => {
+    renderWithProviders('cert-ek-1');
+    expect(await screen.findByText('Subject Alternative Names')).toBeInTheDocument();
+    expect(screen.getByText('dns:tpm.example.com')).toBeInTheDocument();
+    expect(screen.getByText('ip:192.168.1.1')).toBeInTheDocument();
+  });
+
+  it('shows key usage badges', async () => {
+    renderWithProviders('cert-ek-1');
+    expect(await screen.findByText('Key Usage')).toBeInTheDocument();
+    expect(screen.getByText('digitalSignature')).toBeInTheDocument();
+    expect(screen.getByText('keyEncipherment')).toBeInTheDocument();
+  });
+
+  it('shows extended key usage badges', async () => {
+    renderWithProviders('cert-ek-1');
+    expect(await screen.findByText('Extended Key Usage')).toBeInTheDocument();
+    expect(screen.getByText('serverAuth')).toBeInTheDocument();
+  });
+
+  it('renders download buttons', async () => {
+    renderWithProviders('cert-ek-1');
+    expect(await screen.findByRole('button', { name: /download.*pem/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /download.*der/i })).toBeInTheDocument();
+  });
+
+  it('navigates back on Back button click', async () => {
+    renderWithProviders('cert-ek-1');
+    const backBtn = await screen.findByRole('button', { name: /back to certificates list/i });
+    fireEvent.click(backBtn);
+    expect(mockNavigate).toHaveBeenCalledWith('/certificates');
+  });
+
+  it('triggers PEM download on button click', async () => {
+    const { certificatesApi } = await import('@/api/certificates');
+    renderWithProviders('cert-ek-1');
+    const pemBtn = await screen.findByRole('button', { name: /download.*pem/i });
+    fireEvent.click(pemBtn);
+    await vi.waitFor(() => {
+      expect(certificatesApi.downloadPem).toHaveBeenCalledWith('cert-ek-1');
+    });
+  });
+});

--- a/src/pages/Certificates/__tests__/Certificates.test.tsx
+++ b/src/pages/Certificates/__tests__/Certificates.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Certificates } from '../Certificates';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock('@/api/certificates', () => ({
+  certificatesApi: {
+    expirySummary: vi.fn().mockResolvedValue({
+      data: { expired: 2, expiring_30d: 5, expiring_90d: 12, valid: 100, total: 107, timeline_90d: [] },
+    }),
+    list: vi.fn().mockResolvedValue({
+      data: {
+        items: [
+          {
+            id: 'cert-1',
+            type: 'ek',
+            subject_dn: 'CN=TPM-EK',
+            issuer_dn: 'CN=TPM-Vendor-CA',
+            serial_number: 'AA:BB:CC',
+            not_before: '2025-01-01T00:00:00Z',
+            not_after: '2026-12-31T00:00:00Z',
+            public_key_algorithm: 'RSA',
+            public_key_size: 2048,
+            signature_algorithm: 'SHA256withRSA',
+            san: [],
+            key_usage: ['digitalSignature'],
+            extended_key_usage: [],
+            status: 'valid',
+            associated_entity: 'agent-001',
+            chain: [],
+            validation_status: 'valid',
+            chain_valid: null,
+            expiry_category: 'valid',
+          },
+          {
+            id: 'cert-2',
+            type: 'mtls',
+            subject_dn: 'CN=agent-mtls',
+            issuer_dn: 'CN=Keylime-CA',
+            serial_number: 'DD:EE:FF',
+            not_before: '2025-06-01T00:00:00Z',
+            not_after: '2025-07-15T00:00:00Z',
+            public_key_algorithm: 'ECDSA',
+            public_key_size: 256,
+            signature_algorithm: 'SHA256withECDSA',
+            san: [],
+            key_usage: [],
+            extended_key_usage: [],
+            status: 'critical',
+            associated_entity: 'agent-002',
+            chain: [],
+            validation_status: 'valid',
+            chain_valid: null,
+            expiry_category: 'critical_7d',
+          },
+        ],
+      },
+    }),
+    timeline: vi.fn().mockResolvedValue({
+      data: [
+        { date: '2025-07-01', count: 3, expiry_category: 'warning_30d' },
+        { date: '2025-08-15', count: 1, expiry_category: 'warning_90d' },
+      ],
+    }),
+  },
+}));
+
+vi.mock('@/api/client', () => ({
+  default: { get: vi.fn() },
+  getBackendUrl: () => 'http://localhost:8080',
+}));
+
+function renderWithProviders(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockNavigate.mockClear();
+});
+
+describe('Certificates page', () => {
+  it('renders KPI cards with summary values', async () => {
+    renderWithProviders(<Certificates />);
+    expect(await screen.findByText('2')).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+    expect(screen.getByText('100')).toBeInTheDocument();
+    expect(screen.getByText('107')).toBeInTheDocument();
+  });
+
+  it('renders certificate table with data', async () => {
+    renderWithProviders(<Certificates />);
+    expect(await screen.findByText('agent-001')).toBeInTheDocument();
+    expect(screen.getByText('agent-002')).toBeInTheDocument();
+  });
+
+  it('renders type filter buttons', async () => {
+    renderWithProviders(<Certificates />);
+    await screen.findByText('agent-001');
+    const allBtn = screen.getByRole('button', { name: 'All' });
+    expect(allBtn).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'EK' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'AK' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'mTLS' })).toBeInTheDocument();
+  });
+
+  it('activates filter button on click', async () => {
+    renderWithProviders(<Certificates />);
+    await screen.findByText('agent-001');
+    const ekBtn = screen.getByRole('button', { name: 'EK' });
+    fireEvent.click(ekBtn);
+    expect(ekBtn).toHaveAttribute('aria-pressed', 'true');
+    const allBtn = screen.getByRole('button', { name: 'All' });
+    expect(allBtn).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('navigates to certificate detail on row click', async () => {
+    renderWithProviders(<Certificates />);
+    const row = await screen.findByText('agent-001');
+    fireEvent.click(row.closest('tr')!);
+    expect(mockNavigate).toHaveBeenCalledWith('/certificates/cert-1');
+  });
+
+  it('renders timeline legend for accessibility', async () => {
+    renderWithProviders(<Certificates />);
+    expect(await screen.findByText('Valid (>90d)')).toBeInTheDocument();
+    expect(screen.getByText('Emergency (1d)')).toBeInTheDocument();
+    expect(screen.getByText('Action (30d)')).toBeInTheDocument();
+  });
+
+  it('renders page header', () => {
+    renderWithProviders(<Certificates />);
+    expect(screen.getByText('Certificates')).toBeInTheDocument();
+    expect(screen.getByText('Monitor certificate lifecycle and prevent expiry outages')).toBeInTheDocument();
+  });
+});

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -6,6 +6,7 @@ import { AgentDetailPage } from '@/pages/Agents/AgentDetail';
 import { Attestations } from '@/pages/Attestations/Attestations';
 import { Policies } from '@/pages/Policies/Policies';
 import { Certificates } from '@/pages/Certificates/Certificates';
+import { CertificateDetail } from '@/pages/Certificates/CertificateDetail';
 import { Alerts } from '@/pages/Alerts/Alerts';
 import { Performance } from '@/pages/Performance/Performance';
 import { AuditLog } from '@/pages/AuditLog/AuditLog';
@@ -28,6 +29,7 @@ export const router = createBrowserRouter([
       { path: 'attestations', element: <Attestations /> },
       { path: 'policies', element: <Policies /> },
       { path: 'certificates', element: <Certificates /> },
+      { path: 'certificates/:id', element: <CertificateDetail /> },
       { path: 'alerts', element: <Alerts /> },
       { path: 'performance', element: <Performance /> },
       { path: 'audit', element: <AuditLog /> },

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,10 @@
 import '@testing-library/jest-dom';
+
+// Recharts ResponsiveContainer requires ResizeObserver in jsdom
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  globalThis.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+}

--- a/src/types/certificate.ts
+++ b/src/types/certificate.ts
@@ -1,10 +1,6 @@
-export type CertificateType =
-  | 'ek'
-  | 'ak'
-  | 'iak'
-  | 'idevid'
-  | 'mtls'
-  | 'server_cert';
+export type CertificateType = 'ek' | 'ak' | 'mtls';
+
+export type CertificateStatus = 'valid' | 'expiring_soon' | 'critical' | 'expired';
 
 export type ExpiryCategory =
   | 'valid'
@@ -30,15 +26,26 @@ export interface Certificate {
   san: string[];
   key_usage: string[];
   extended_key_usage: string[];
-  associated_entity: string;
-  chain: Certificate[];
-  validation_status: ValidationStatus;
+  status: CertificateStatus;
   expiry_category: ExpiryCategory;
+  associated_entity: string;
+  validation_status: ValidationStatus;
+  chain_valid: boolean | null;
+  chain: Certificate[];
+  raw_pem?: string;
 }
 
 export interface CertificateExpirySummary {
   expired: number;
   expiring_30d: number;
+  expiring_90d: number;
   valid: number;
   total: number;
+  timeline_90d: CertificateTimelineEntry[];
+}
+
+export interface CertificateTimelineEntry {
+  date: string;
+  count: number;
+  expiry_category: ExpiryCategory;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,7 @@
 export type { Agent, AgentState, AgentListParams, AgentPcrValues, ImaLogEntry, BootLogEntry } from './agent';
 export type { Attestation, AttestationSummary, AttestationTimelinePoint, FailureCategoryCount, AttestationIncident, FailureType } from './attestation';
 export type { Policy, PolicyVersion, PolicyImpactResult, PolicyKind, ApprovalState } from './policy';
-export type { Certificate, CertificateExpirySummary, CertificateType, ExpiryCategory } from './certificate';
+export type { Certificate, CertificateExpirySummary, CertificateStatus, CertificateTimelineEntry, CertificateType, ExpiryCategory, ValidationStatus } from './certificate';
 export type { Alert, AlertSummary, AlertSeverity, AlertState, AlertType } from './alert';
 export type { AuditLogEntry, HashChainStatus, AuditSeverity, AuditAction } from './audit';
 


### PR DESCRIPTION
Scope certificate types to EK, AK, and mTLS only, removing IAK, IDevID, and server_cert. Remove renewal API methods (FR-053). Add certificate detail page with chain visualization, PEM/DER download, and full field display. Add 90-day expiry timeline chart with tiered color coding and WCAG-compliant legend. Add type filtering, row-click navigation, and expiry KPI cards (including 90d). Implement agent detail Certificates tab with grouped cert cards and expiry countdown. Align frontend types with backend response (status, chain_valid, raw_pem, expiring_90d, timeline_90d fields).