### PR TITLE
Extend test coverage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@typescript-eslint/eslint-plugin": "^8.59.1",
         "@typescript-eslint/parser": "^8.59.1",
         "@vitejs/plugin-react": "^6.0.1",
+        "@vitest/coverage-v8": "^4.1.5",
         "eslint": "^9.15.0",
         "eslint-plugin-react-hooks": "^5.0.0",
         "eslint-plugin-react-refresh": "^0.5.2",
@@ -95,13 +96,38 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -110,6 +136,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -528,10 +578,31 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
@@ -1331,6 +1402,37 @@
         }
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.5",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.5",
+        "vitest": "4.1.5"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.5",
       "dev": true,
@@ -1507,6 +1609,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -2412,6 +2533,13 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ignore": {
       "version": "7.0.5",
       "dev": true,
@@ -2494,6 +2622,45 @@
       "version": "2.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -2897,6 +3064,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@typescript-eslint/eslint-plugin": "^8.59.1",
     "@typescript-eslint/parser": "^8.59.1",
     "@vitejs/plugin-react": "^6.0.1",
+    "@vitest/coverage-v8": "^4.1.5",
     "eslint": "^9.15.0",
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.5.2",

--- a/src/components/Layout/__tests__/Sidebar.test.tsx
+++ b/src/components/Layout/__tests__/Sidebar.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Sidebar } from '../Sidebar';
+
+vi.mock('@/api/performance', () => ({
+  performanceApi: { integrations: vi.fn().mockResolvedValue({ data: [] }) },
+}));
+
+vi.mock('@/api/settings', () => ({
+  settingsApi: { getKeylime: vi.fn().mockResolvedValue({ data: {} }) },
+}));
+
+vi.mock('@/api/client', () => ({
+  default: { get: vi.fn() },
+  getBackendUrl: () => 'http://localhost:8080',
+}));
+
+function renderSidebar() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <Sidebar />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('Sidebar', () => {
+  it('renders the brand logo link', () => {
+    renderSidebar();
+    expect(screen.getByText('Keylime Dashboard')).toBeInTheDocument();
+  });
+
+  it('renders all navigation items', () => {
+    renderSidebar();
+    const labels = [
+      'Dashboard', 'Agents', 'Policies', 'Alerts', 'Attestations',
+      'Certificates', 'Performance', 'Audit Log', 'Integrations', 'Settings',
+    ];
+    for (const label of labels) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  });
+
+  it('renders nav element with accessible label', () => {
+    renderSidebar();
+    expect(screen.getByRole('navigation', { name: 'Main navigation' })).toBeInTheDocument();
+  });
+});

--- a/src/components/Layout/__tests__/TopBar.test.tsx
+++ b/src/components/Layout/__tests__/TopBar.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { TopBar } from '../TopBar';
+import { useAuthStore } from '@/store/authStore';
+import type { User } from '@/types';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const admin: User = { id: '1', name: 'Jane Doe', email: 'j@t.com', role: 'admin' };
+
+beforeEach(() => {
+  mockNavigate.mockClear();
+  sessionStorage.clear();
+  useAuthStore.setState({ user: admin, isAuthenticated: true });
+});
+
+function renderTopBar(props?: Partial<Parameters<typeof TopBar>[0]>) {
+  const defaults = {
+    selectedTimeRange: '24h',
+    onTimeRangeChange: vi.fn(),
+    onToggleSidebar: vi.fn(),
+  };
+  return render(
+    <MemoryRouter>
+      <TopBar {...defaults} {...props} />
+    </MemoryRouter>,
+  );
+}
+
+describe('TopBar', () => {
+  it('renders user initials from name', () => {
+    renderTopBar();
+    expect(screen.getByText('JD')).toBeInTheDocument();
+  });
+
+  it('renders user name', () => {
+    renderTopBar();
+    expect(screen.getByText('Jane Doe')).toBeInTheDocument();
+  });
+
+  it('renders "?" for guest when no user', () => {
+    useAuthStore.setState({ user: null, isAuthenticated: false });
+    renderTopBar();
+    expect(screen.getByText('?')).toBeInTheDocument();
+  });
+
+  it('renders time range buttons', () => {
+    renderTopBar();
+    expect(screen.getByText('1h')).toBeInTheDocument();
+    expect(screen.getByText('6h')).toBeInTheDocument();
+    expect(screen.getByText('24h')).toBeInTheDocument();
+    expect(screen.getByText('7d')).toBeInTheDocument();
+    expect(screen.getByText('30d')).toBeInTheDocument();
+  });
+
+  it('calls onTimeRangeChange when a time button is clicked', () => {
+    const onChange = vi.fn();
+    renderTopBar({ onTimeRangeChange: onChange });
+    fireEvent.click(screen.getByText('7d'));
+    expect(onChange).toHaveBeenCalledWith('7d');
+  });
+
+  it('submits search and navigates to agents', () => {
+    renderTopBar();
+    const input = screen.getByLabelText('Search agents');
+    fireEvent.change(input, { target: { value: 'abc-123' } });
+    fireEvent.submit(input.closest('form')!);
+    expect(mockNavigate).toHaveBeenCalledWith('/agents?q=abc-123');
+  });
+
+  it('calls onToggleSidebar', () => {
+    const toggle = vi.fn();
+    renderTopBar({ onToggleSidebar: toggle });
+    fireEvent.click(screen.getByLabelText('Toggle sidebar'));
+    expect(toggle).toHaveBeenCalledOnce();
+  });
+
+  it('navigates to settings page', () => {
+    renderTopBar();
+    fireEvent.click(screen.getByLabelText('Settings'));
+    expect(mockNavigate).toHaveBeenCalledWith('/settings');
+  });
+});

--- a/src/components/common/__tests__/DataTable.test.tsx
+++ b/src/components/common/__tests__/DataTable.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DataTable } from '../DataTable';
+
+const columns = [
+  { key: 'name', header: 'Name', sortable: true },
+  { key: 'status', header: 'Status' },
+];
+
+const data = [
+  { id: '1', name: 'Bravo', status: 'ok' },
+  { id: '2', name: 'Alpha', status: 'fail' },
+  { id: '3', name: 'Charlie', status: 'ok' },
+];
+
+describe('DataTable', () => {
+  it('renders column headers', () => {
+    render(<DataTable columns={columns} data={data} keyField="id" />);
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Status')).toBeInTheDocument();
+  });
+
+  it('renders row data', () => {
+    render(<DataTable columns={columns} data={data} keyField="id" />);
+    expect(screen.getByText('Bravo')).toBeInTheDocument();
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+    expect(screen.getByText('Charlie')).toBeInTheDocument();
+  });
+
+  it('shows empty message when data is empty', () => {
+    render(<DataTable columns={columns} data={[]} keyField="id" emptyMessage="Nothing here" />);
+    expect(screen.getByText('Nothing here')).toBeInTheDocument();
+  });
+
+  it('shows default empty message', () => {
+    render(<DataTable columns={columns} data={[]} keyField="id" />);
+    expect(screen.getByText('No data available')).toBeInTheDocument();
+  });
+
+  it('sorts ascending then descending on header click', () => {
+    render(<DataTable columns={columns} data={data} keyField="id" />);
+    fireEvent.click(screen.getByText('Name'));
+    const rows = screen.getAllByRole('row');
+    expect(rows[1]).toHaveTextContent('Alpha');
+    expect(rows[2]).toHaveTextContent('Bravo');
+    expect(rows[3]).toHaveTextContent('Charlie');
+
+    fireEvent.click(screen.getByText('Name'));
+    const rows2 = screen.getAllByRole('row');
+    expect(rows2[1]).toHaveTextContent('Charlie');
+    expect(rows2[2]).toHaveTextContent('Bravo');
+    expect(rows2[3]).toHaveTextContent('Alpha');
+  });
+
+  it('calls onRowClick with the row data', () => {
+    const onClick = vi.fn();
+    render(<DataTable columns={columns} data={data} keyField="id" onRowClick={onClick} />);
+    fireEvent.click(screen.getByText('Alpha'));
+    expect(onClick).toHaveBeenCalledWith(data[1]);
+  });
+
+  it('supports selectable rows with checkboxes', () => {
+    const onSelection = vi.fn();
+    render(
+      <DataTable columns={columns} data={data} keyField="id" selectable onSelectionChange={onSelection} />,
+    );
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes).toHaveLength(4); // 1 select-all + 3 rows
+
+    fireEvent.click(checkboxes[1]);
+    expect(onSelection).toHaveBeenCalledWith(['1']);
+  });
+
+  it('select-all toggles all rows', () => {
+    const onSelection = vi.fn();
+    render(
+      <DataTable columns={columns} data={data} keyField="id" selectable onSelectionChange={onSelection} />,
+    );
+    const selectAll = screen.getByLabelText('Select all rows');
+    fireEvent.click(selectAll);
+    expect(onSelection).toHaveBeenCalledWith(['1', '2', '3']);
+
+    fireEvent.click(selectAll);
+    expect(onSelection).toHaveBeenCalledWith([]);
+  });
+
+  it('uses custom render function for column', () => {
+    const cols = [
+      { key: 'name', header: 'Name', render: (row: { name: string }) => <b>{row.name}!</b> },
+    ];
+    render(<DataTable columns={cols} data={[{ id: '1', name: 'Test' }]} keyField="id" />);
+    expect(screen.getByText('Test!')).toBeInTheDocument();
+  });
+});

--- a/src/components/common/__tests__/KpiCard.test.tsx
+++ b/src/components/common/__tests__/KpiCard.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { KpiCard } from '../KpiCard';
+
+function wrap(ui: React.ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+describe('KpiCard', () => {
+  it('renders title and value', () => {
+    wrap(<KpiCard title="Agents" value={42} />);
+    expect(screen.getByText('Agents')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+  });
+
+  it('renders subtitle when provided', () => {
+    wrap(<KpiCard title="T" value={0} subtitle="last 24h" />);
+    expect(screen.getByText('last 24h')).toBeInTheDocument();
+  });
+
+  it('renders icon when provided', () => {
+    wrap(<KpiCard title="T" value={0} icon={<span data-testid="icon">!</span>} />);
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+  });
+
+  it('applies variant class', () => {
+    const { container } = wrap(<KpiCard title="T" value={0} variant="danger" />);
+    expect(container.querySelector('.kpi-card--danger')).toBeTruthy();
+  });
+
+  it('renders as link when linkTo is provided', () => {
+    wrap(<KpiCard title="Alerts" value={5} linkTo="/alerts" />);
+    const link = screen.getByRole('link', { name: /Alerts: 5/ });
+    expect(link).toHaveAttribute('href', '/alerts');
+  });
+
+  it('renders as button when onClick is provided', () => {
+    const onClick = vi.fn();
+    wrap(<KpiCard title="Action" value={1} onClick={onClick} />);
+    const btn = screen.getByRole('button');
+    fireEvent.click(btn);
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it('responds to Enter key when onClick is provided', () => {
+    const onClick = vi.fn();
+    wrap(<KpiCard title="Action" value={1} onClick={onClick} />);
+    const btn = screen.getByRole('button');
+    fireEvent.keyDown(btn, { key: 'Enter' });
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it('responds to Space key when onClick is provided', () => {
+    const onClick = vi.fn();
+    wrap(<KpiCard title="Action" value={1} onClick={onClick} />);
+    const btn = screen.getByRole('button');
+    fireEvent.keyDown(btn, { key: ' ' });
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/common/__tests__/StatusBadge.test.tsx
+++ b/src/components/common/__tests__/StatusBadge.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StatusBadge } from '../StatusBadge';
+
+describe('StatusBadge', () => {
+  it('renders the label text', () => {
+    render(<StatusBadge label="get_quote" />);
+    expect(screen.getByText('get_quote')).toBeInTheDocument();
+  });
+
+  it('applies explicit variant class', () => {
+    const { container } = render(<StatusBadge label="custom" variant="warning" />);
+    expect(container.firstChild).toHaveClass('status-badge--warning');
+  });
+
+  it('auto-maps agent state labels', () => {
+    const { container: c1 } = render(<StatusBadge label="get_quote" />);
+    expect(c1.firstChild).toHaveClass('status-badge--success');
+
+    const { container: c2 } = render(<StatusBadge label="failed" />);
+    expect(c2.firstChild).toHaveClass('status-badge--danger');
+
+    const { container: c3 } = render(<StatusBadge label="retry" />);
+    expect(c3.firstChild).toHaveClass('status-badge--warning');
+
+    const { container: c4 } = render(<StatusBadge label="terminated" />);
+    expect(c4.firstChild).toHaveClass('status-badge--neutral');
+  });
+
+  it('auto-maps service status labels', () => {
+    const { container: c1 } = render(<StatusBadge label="up" />);
+    expect(c1.firstChild).toHaveClass('status-badge--success');
+
+    const { container: c2 } = render(<StatusBadge label="down" />);
+    expect(c2.firstChild).toHaveClass('status-badge--danger');
+  });
+
+  it('auto-maps certificate expiry categories', () => {
+    const { container: c1 } = render(<StatusBadge label="warning_90d" />);
+    expect(c1.firstChild).toHaveClass('status-badge--info');
+
+    const { container: c2 } = render(<StatusBadge label="warning_30d" />);
+    expect(c2.firstChild).toHaveClass('status-badge--warning');
+
+    const { container: c3 } = render(<StatusBadge label="critical_7d" />);
+    expect(c3.firstChild).toHaveClass('status-badge--danger');
+
+    const { container: c4 } = render(<StatusBadge label="critical_1d" />);
+    expect(c4.firstChild).toHaveClass('status-badge--danger');
+  });
+
+  it('falls back to neutral for unknown labels', () => {
+    const { container } = render(<StatusBadge label="something_unknown" />);
+    expect(container.firstChild).toHaveClass('status-badge--neutral');
+  });
+
+  it('is case-insensitive for auto-mapping', () => {
+    const { container } = render(<StatusBadge label="VALID" />);
+    expect(container.firstChild).toHaveClass('status-badge--success');
+  });
+
+  it('uses "--" for null-ish label', () => {
+    render(<StatusBadge label={null as unknown as string} />);
+    expect(screen.getByText('--')).toBeInTheDocument();
+  });
+});

--- a/src/pages/Agents/__tests__/AgentDetail.test.tsx
+++ b/src/pages/Agents/__tests__/AgentDetail.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AgentDetailPage } from '../AgentDetail';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock('@/api/agents', () => ({
+  agentsApi: {
+    get: vi.fn().mockResolvedValue({
+      data: {
+        id: 'agent-001',
+        ip: '10.0.0.1',
+        port: 9002,
+        state: 'GET_QUOTE',
+        attestation_mode: 'Pull',
+        tpm_policy: '{"0":["0xabcd"],"mask":"0x1"}',
+      },
+    }),
+    timeline: vi.fn().mockResolvedValue({ data: [] }),
+    imaLog: vi.fn().mockResolvedValue({ data: { entries: [] } }),
+    bootLog: vi.fn().mockResolvedValue({ data: { entries: [] } }),
+    certificates: vi.fn().mockResolvedValue({
+      data: [
+        {
+          id: 'c1', type: 'ek', subject_dn: 'CN=TPM-EK', issuer_dn: 'CN=Vendor',
+          serial_number: 'AA', not_before: '2025-01-01', not_after: '2027-12-31',
+          public_key_algorithm: 'RSA', public_key_size: 2048, signature_algorithm: 'SHA256',
+          san: [], key_usage: [], extended_key_usage: [], status: 'valid',
+          expiry_category: 'valid', associated_entity: 'agent-001',
+          validation_status: 'valid', chain_valid: null, chain: [],
+        },
+      ],
+    }),
+    raw: vi.fn().mockResolvedValue({ data: { test: 'data' } }),
+  },
+}));
+
+vi.mock('@/api/client', () => ({
+  default: { get: vi.fn() },
+  getBackendUrl: () => 'http://localhost:8080',
+}));
+
+function renderDetail() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/agents/agent-001']}>
+        <Routes>
+          <Route path="/agents/:id" element={<AgentDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockNavigate.mockClear();
+});
+
+describe('AgentDetailPage', () => {
+  it('renders agent id and state badge', async () => {
+    renderDetail();
+    expect(await screen.findByText('agent-001')).toBeInTheDocument();
+    expect(screen.getByText('GET_QUOTE')).toBeInTheDocument();
+  });
+
+  it('renders back button', async () => {
+    renderDetail();
+    const back = await screen.findByLabelText('Back to agents list');
+    fireEvent.click(back);
+    expect(mockNavigate).toHaveBeenCalledWith('/agents');
+  });
+
+  it('renders all tab buttons', async () => {
+    renderDetail();
+    await screen.findByText('agent-001');
+    for (const tab of ['TPM Policy', 'IMA Log', 'Boot Log', 'Certificates', 'Timeline', 'Raw Data']) {
+      expect(screen.getByRole('tab', { name: tab })).toBeInTheDocument();
+    }
+  });
+
+  it('TPM Policy tab shows PCR index and mask', async () => {
+    renderDetail();
+    await screen.findByText('agent-001');
+    expect(screen.getByText('0x1')).toBeInTheDocument();
+    expect(screen.getByText('0')).toBeInTheDocument();
+    expect(screen.getByText('0xabcd')).toBeInTheDocument();
+  });
+
+  it('Certificates tab shows cert cards', async () => {
+    renderDetail();
+    await screen.findByText('agent-001');
+    fireEvent.click(screen.getByRole('tab', { name: 'Certificates' }));
+    expect(await screen.findByText('EK Certificate')).toBeInTheDocument();
+  });
+
+  it('Timeline tab shows empty placeholder', async () => {
+    renderDetail();
+    await screen.findByText('agent-001');
+    fireEvent.click(screen.getByRole('tab', { name: 'Timeline' }));
+    expect(await screen.findByText('No attestation timeline data')).toBeInTheDocument();
+  });
+});

--- a/src/pages/Agents/__tests__/AgentList.test.tsx
+++ b/src/pages/Agents/__tests__/AgentList.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AgentList } from '../AgentList';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock('@/api/agents', () => ({
+  agentsApi: {
+    list: vi.fn().mockResolvedValue({
+      data: {
+        items: [
+          { id: 'agent-001', ip: '10.0.0.1', port: 9002, state: 'GET_QUOTE', attestation_mode: 'Pull', last_attestation: '2025-06-01T10:00:00Z', failure_count: 0 },
+          { id: 'agent-002', ip: '10.0.0.2', port: 9002, state: 'FAILED', attestation_mode: 'Pull', last_attestation: '2025-06-01T09:00:00Z', failure_count: 3 },
+        ],
+        total_pages: 1,
+        total_items: 2,
+      },
+    }),
+    search: vi.fn().mockResolvedValue({ data: [] }),
+  },
+}));
+
+vi.mock('@/api/performance', () => ({
+  performanceApi: { integrations: vi.fn().mockResolvedValue({ data: [] }) },
+}));
+
+vi.mock('@/api/settings', () => ({
+  settingsApi: { getKeylime: vi.fn().mockResolvedValue({ data: {} }) },
+}));
+
+vi.mock('@/api/client', () => ({
+  default: { get: vi.fn() },
+  getBackendUrl: () => 'http://localhost:8080',
+}));
+
+function renderList() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <AgentList />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockNavigate.mockClear();
+});
+
+describe('AgentList page', () => {
+  it('renders page header', () => {
+    renderList();
+    expect(screen.getByText('Agents')).toBeInTheDocument();
+  });
+
+  it('renders agent rows', async () => {
+    renderList();
+    expect(await screen.findByText('agent-001')).toBeInTheDocument();
+    expect(screen.getByText('agent-002')).toBeInTheDocument();
+  });
+
+  it('renders search input', () => {
+    renderList();
+    expect(screen.getByLabelText('Search agents')).toBeInTheDocument();
+  });
+
+  it('renders state and mode filter selects', () => {
+    renderList();
+    expect(screen.getByLabelText('Filter by state')).toBeInTheDocument();
+    expect(screen.getByLabelText('Filter by mode')).toBeInTheDocument();
+  });
+
+  it('renders Show All Agents reset button', () => {
+    renderList();
+    expect(screen.getByText('Show All Agents')).toBeInTheDocument();
+  });
+
+  it('renders agent state chart section', async () => {
+    renderList();
+    await screen.findByText('agent-001');
+    expect(screen.getByText('Agent State Distribution')).toBeInTheDocument();
+  });
+});

--- a/src/pages/Alerts/__tests__/Alerts.test.tsx
+++ b/src/pages/Alerts/__tests__/Alerts.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Alerts } from '../Alerts';
+
+vi.mock('@/api/alerts', () => ({
+  alertsApi: {
+    summary: vi.fn().mockResolvedValue({
+      data: { critical: 3, warnings: 7, info: 2, active_alerts: 10, active_critical: 3 },
+    }),
+    list: vi.fn().mockResolvedValue({
+      data: {
+        items: [
+          {
+            id: 'a1', severity: 'critical', type: 'attestation_failure',
+            state: 'new', description: 'Agent failed attestation',
+            affected_agents: ['ag1', 'ag2'], created_timestamp: '2025-06-01T10:00:00Z',
+          },
+          {
+            id: 'a2', severity: 'warning', type: 'cert_expiry',
+            state: 'acknowledged', description: 'Cert expiring soon',
+            affected_agents: ['ag3'], created_timestamp: '2025-06-02T12:00:00Z',
+          },
+        ],
+      },
+    }),
+  },
+}));
+
+vi.mock('@/api/client', () => ({
+  default: { get: vi.fn() },
+  getBackendUrl: () => 'http://localhost:8080',
+}));
+
+function renderAlerts() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <Alerts />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('Alerts page', () => {
+  it('renders page header', () => {
+    renderAlerts();
+    expect(screen.getByText('Alert Center')).toBeInTheDocument();
+  });
+
+  it('renders KPI cards with summary counts', async () => {
+    renderAlerts();
+    expect(await screen.findByText('3')).toBeInTheDocument();
+    expect(screen.getByText('7')).toBeInTheDocument();
+    const infoCards = screen.getAllByText('2');
+    expect(infoCards.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders alert table rows', async () => {
+    renderAlerts();
+    expect(await screen.findByText('Agent failed attestation')).toBeInTheDocument();
+    expect(screen.getByText('Cert expiring soon')).toBeInTheDocument();
+  });
+
+  it('renders filter dropdowns', async () => {
+    renderAlerts();
+    await screen.findByText('Agent failed attestation');
+    expect(screen.getByLabelText('Filter by severity')).toBeInTheDocument();
+    expect(screen.getByLabelText('Filter by state')).toBeInTheDocument();
+    expect(screen.getByLabelText('Filter by type')).toBeInTheDocument();
+  });
+
+  it('renders Ack button for new alerts', async () => {
+    renderAlerts();
+    expect(await screen.findByText('Ack')).toBeInTheDocument();
+  });
+
+  it('renders Investigate button for new and acknowledged alerts', async () => {
+    renderAlerts();
+    const investigateBtns = await screen.findAllByText('Investigate');
+    expect(investigateBtns).toHaveLength(2);
+  });
+
+  it('renders pie chart section titles', async () => {
+    renderAlerts();
+    await screen.findByText('Agent failed attestation');
+    expect(screen.getByText('By Severity')).toBeInTheDocument();
+    expect(screen.getByText('By Type')).toBeInTheDocument();
+    expect(screen.getByText('By State')).toBeInTheDocument();
+  });
+
+  it('has a Show All Alerts reset button', () => {
+    renderAlerts();
+    expect(screen.getByText('Show All Alerts')).toBeInTheDocument();
+  });
+});

--- a/src/pages/Dashboard/__tests__/Dashboard.test.tsx
+++ b/src/pages/Dashboard/__tests__/Dashboard.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Dashboard } from '../Dashboard';
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+    useOutletContext: () => ({ timeRange: '24h' }),
+  };
+});
+
+vi.mock('@/api/agents', () => ({
+  agentsApi: {
+    list: vi.fn().mockResolvedValue({
+      data: {
+        items: [
+          { id: 'a1', state: 'GET_QUOTE', attestation_mode: 'Pull' },
+          { id: 'a2', state: 'FAILED', attestation_mode: 'Pull' },
+          { id: 'a3', state: 'PASS', attestation_mode: 'Push' },
+        ],
+        total_items: 3,
+      },
+    }),
+  },
+}));
+
+vi.mock('@/api/attestations', () => ({
+  attestationsApi: {
+    summary: vi.fn().mockResolvedValue({ data: null }),
+    timeline: vi.fn().mockResolvedValue({ data: [] }),
+  },
+}));
+
+vi.mock('@/api/alerts', () => ({
+  alertsApi: {
+    summary: vi.fn().mockResolvedValue({
+      data: { active_alerts: 5, active_critical: 2, critical: 2, warnings: 3, info: 1 },
+    }),
+    list: vi.fn().mockResolvedValue({
+      data: {
+        items: [
+          { id: 'al1', severity: 'critical', type: 'attestation_failure', state: 'new', description: 'test', affected_agents: ['a1'], created_timestamp: '2025-01-01' },
+          { id: 'al2', severity: 'warning', type: 'cert_expiry', state: 'acknowledged', description: 'test2', affected_agents: [], created_timestamp: '2025-01-02' },
+        ],
+      },
+    }),
+  },
+}));
+
+vi.mock('@/api/client', () => ({
+  default: { get: vi.fn() },
+  getBackendUrl: () => 'http://localhost:8080',
+}));
+
+function renderDashboard() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <Dashboard />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('Dashboard', () => {
+  it('renders fleet overview header', () => {
+    renderDashboard();
+    expect(screen.getByText('Fleet Overview')).toBeInTheDocument();
+  });
+
+  it('renders KPI cards', async () => {
+    renderDashboard();
+    expect(await screen.findByText('Total Agents')).toBeInTheDocument();
+    expect(screen.getByText('Attestation Success Rate')).toBeInTheDocument();
+    expect(screen.getByText('Failed Attestations')).toBeInTheDocument();
+    expect(screen.getByText('Urgent Alerts')).toBeInTheDocument();
+  });
+
+  it('uses fallback agent attestation stats when summary is null', async () => {
+    renderDashboard();
+    // 2 of 3 agents are attested (GET_QUOTE, FAILED, PASS); 1 failed → 66.67%
+    expect(await screen.findByText('66.67%')).toBeInTheDocument();
+  });
+
+  it('renders total agents from API', async () => {
+    renderDashboard();
+    expect(await screen.findByText('3')).toBeInTheDocument();
+  });
+
+  it('renders alert summary subtitle', async () => {
+    renderDashboard();
+    expect(await screen.findByText('2 critical, 3 warnings')).toBeInTheDocument();
+  });
+
+  it('renders chart dimension toggle buttons', async () => {
+    renderDashboard();
+    await screen.findByText('Total Agents');
+    expect(screen.getByText('severity')).toBeInTheDocument();
+    expect(screen.getByText('type')).toBeInTheDocument();
+    expect(screen.getByText('state')).toBeInTheDocument();
+  });
+});

--- a/src/pages/Login/__tests__/Login.test.tsx
+++ b/src/pages/Login/__tests__/Login.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { Login } from '../Login';
+import { useAuthStore } from '@/store/authStore';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+beforeEach(() => {
+  mockNavigate.mockClear();
+  sessionStorage.clear();
+  useAuthStore.setState({ user: null, isAuthenticated: false });
+});
+
+describe('Login page', () => {
+  it('renders the brand heading', () => {
+    render(<MemoryRouter><Login /></MemoryRouter>);
+    expect(screen.getByText('Keylime Monitoring Dashboard')).toBeInTheDocument();
+  });
+
+  it('renders OIDC and Demo login buttons', () => {
+    render(<MemoryRouter><Login /></MemoryRouter>);
+    expect(screen.getByText('Sign in with OIDC/SAML')).toBeInTheDocument();
+    expect(screen.getByText('Demo Login (Development)')).toBeInTheDocument();
+  });
+
+  it('demo login sets auth state and navigates home', () => {
+    render(<MemoryRouter><Login /></MemoryRouter>);
+    fireEvent.click(screen.getByText('Demo Login (Development)'));
+    const state = useAuthStore.getState();
+    expect(state.isAuthenticated).toBe(true);
+    expect(state.user?.role).toBe('admin');
+    expect(mockNavigate).toHaveBeenCalledWith('/');
+  });
+
+  it('OIDC button also triggers demo login in dev mode', () => {
+    render(<MemoryRouter><Login /></MemoryRouter>);
+    fireEvent.click(screen.getByText('Sign in with OIDC/SAML'));
+    expect(useAuthStore.getState().isAuthenticated).toBe(true);
+    expect(mockNavigate).toHaveBeenCalledWith('/');
+  });
+});

--- a/src/store/__tests__/authStore.test.ts
+++ b/src/store/__tests__/authStore.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useAuthStore } from '../authStore';
+import type { User } from '@/types';
+
+const viewer: User = { id: '1', name: 'View', email: 'v@test.com', role: 'viewer' };
+const operator: User = { id: '2', name: 'Op', email: 'o@test.com', role: 'operator' };
+const admin: User = { id: '3', name: 'Adm', email: 'a@test.com', role: 'admin' };
+
+beforeEach(() => {
+  sessionStorage.clear();
+  useAuthStore.setState({ user: null, isAuthenticated: false });
+});
+
+describe('authStore', () => {
+  describe('login', () => {
+    it('sets user and isAuthenticated', () => {
+      useAuthStore.getState().login(viewer, 'tok-1');
+      const s = useAuthStore.getState();
+      expect(s.user).toEqual(viewer);
+      expect(s.isAuthenticated).toBe(true);
+    });
+
+    it('stores token in sessionStorage', () => {
+      useAuthStore.getState().login(operator, 'tok-2');
+      expect(sessionStorage.getItem('access_token')).toBe('tok-2');
+    });
+  });
+
+  describe('logout', () => {
+    it('clears user and isAuthenticated', () => {
+      useAuthStore.getState().login(admin, 'tok-3');
+      useAuthStore.getState().logout();
+      const s = useAuthStore.getState();
+      expect(s.user).toBeNull();
+      expect(s.isAuthenticated).toBe(false);
+    });
+
+    it('removes token from sessionStorage', () => {
+      useAuthStore.getState().login(admin, 'tok-4');
+      useAuthStore.getState().logout();
+      expect(sessionStorage.getItem('access_token')).toBeNull();
+    });
+  });
+
+  describe('hasRole', () => {
+    it('returns false when no user is logged in', () => {
+      expect(useAuthStore.getState().hasRole('viewer')).toBe(false);
+    });
+
+    it('viewer has viewer role only', () => {
+      useAuthStore.getState().login(viewer, 't');
+      expect(useAuthStore.getState().hasRole('viewer')).toBe(true);
+      expect(useAuthStore.getState().hasRole('operator')).toBe(false);
+      expect(useAuthStore.getState().hasRole('admin')).toBe(false);
+    });
+
+    it('operator has viewer and operator roles', () => {
+      useAuthStore.getState().login(operator, 't');
+      expect(useAuthStore.getState().hasRole('viewer')).toBe(true);
+      expect(useAuthStore.getState().hasRole('operator')).toBe(true);
+      expect(useAuthStore.getState().hasRole('admin')).toBe(false);
+    });
+
+    it('admin has all roles', () => {
+      useAuthStore.getState().login(admin, 't');
+      expect(useAuthStore.getState().hasRole('viewer')).toBe(true);
+      expect(useAuthStore.getState().hasRole('operator')).toBe(true);
+      expect(useAuthStore.getState().hasRole('admin')).toBe(true);
+    });
+  });
+
+  describe('canWrite', () => {
+    it('returns false for viewer', () => {
+      useAuthStore.getState().login(viewer, 't');
+      expect(useAuthStore.getState().canWrite()).toBe(false);
+    });
+
+    it('returns true for operator', () => {
+      useAuthStore.getState().login(operator, 't');
+      expect(useAuthStore.getState().canWrite()).toBe(true);
+    });
+
+    it('returns true for admin', () => {
+      useAuthStore.getState().login(admin, 't');
+      expect(useAuthStore.getState().canWrite()).toBe(true);
+    });
+  });
+
+  describe('isAdmin', () => {
+    it('returns false for viewer', () => {
+      useAuthStore.getState().login(viewer, 't');
+      expect(useAuthStore.getState().isAdmin()).toBe(false);
+    });
+
+    it('returns false for operator', () => {
+      useAuthStore.getState().login(operator, 't');
+      expect(useAuthStore.getState().isAdmin()).toBe(false);
+    });
+
+    it('returns true for admin', () => {
+      useAuthStore.getState().login(admin, 't');
+      expect(useAuthStore.getState().isAdmin()).toBe(true);
+    });
+  });
+});

--- a/src/store/__tests__/visualizationStore.test.ts
+++ b/src/store/__tests__/visualizationStore.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useVisualizationStore, formatTimestamp } from '../visualizationStore';
+
+beforeEach(() => {
+  localStorage.clear();
+  useVisualizationStore.setState({
+    theme: 'light',
+    autoRefresh: true,
+    refreshInterval: 30,
+    defaultTimeRange: '24h',
+    showChartLabels: true,
+    tablePageSize: 25,
+    timezone: 'UTC',
+    timezoneAutoDetect: true,
+    dateFormat: 'DD-MM-YYYY',
+    timeFormat: '24h',
+    integrationsViewMode: 'topology',
+  });
+});
+
+describe('visualizationStore', () => {
+  describe('setters persist to localStorage', () => {
+    it('setTheme updates state and saves', () => {
+      useVisualizationStore.getState().setTheme('dark');
+      expect(useVisualizationStore.getState().theme).toBe('dark');
+      const stored = JSON.parse(localStorage.getItem('visualization-settings')!);
+      expect(stored.theme).toBe('dark');
+    });
+
+    it('setAutoRefresh persists', () => {
+      useVisualizationStore.getState().setAutoRefresh(false);
+      expect(useVisualizationStore.getState().autoRefresh).toBe(false);
+      const stored = JSON.parse(localStorage.getItem('visualization-settings')!);
+      expect(stored.autoRefresh).toBe(false);
+    });
+
+    it('setRefreshInterval persists', () => {
+      useVisualizationStore.getState().setRefreshInterval(60);
+      expect(useVisualizationStore.getState().refreshInterval).toBe(60);
+    });
+
+    it('setDefaultTimeRange persists', () => {
+      useVisualizationStore.getState().setDefaultTimeRange('7d');
+      expect(useVisualizationStore.getState().defaultTimeRange).toBe('7d');
+    });
+
+    it('setShowChartLabels persists', () => {
+      useVisualizationStore.getState().setShowChartLabels(false);
+      expect(useVisualizationStore.getState().showChartLabels).toBe(false);
+    });
+
+    it('setTablePageSize persists', () => {
+      useVisualizationStore.getState().setTablePageSize(50);
+      expect(useVisualizationStore.getState().tablePageSize).toBe(50);
+    });
+
+    it('setTimezone persists', () => {
+      useVisualizationStore.getState().setTimezone('America/New_York');
+      expect(useVisualizationStore.getState().timezone).toBe('America/New_York');
+    });
+
+    it('setDateFormat persists', () => {
+      useVisualizationStore.getState().setDateFormat('YYYY-MM-DD');
+      expect(useVisualizationStore.getState().dateFormat).toBe('YYYY-MM-DD');
+    });
+
+    it('setTimeFormat persists', () => {
+      useVisualizationStore.getState().setTimeFormat('12h');
+      expect(useVisualizationStore.getState().timeFormat).toBe('12h');
+    });
+
+    it('setIntegrationsViewMode persists', () => {
+      useVisualizationStore.getState().setIntegrationsViewMode('list');
+      expect(useVisualizationStore.getState().integrationsViewMode).toBe('list');
+      const stored = JSON.parse(localStorage.getItem('visualization-settings')!);
+      expect(stored.integrationsViewMode).toBe('list');
+    });
+  });
+
+  describe('setTimezoneAutoDetect', () => {
+    it('auto-detects browser timezone when enabled', () => {
+      useVisualizationStore.getState().setTimezone('America/Chicago');
+      useVisualizationStore.getState().setTimezoneAutoDetect(true);
+      const tz = useVisualizationStore.getState().timezone;
+      expect(tz).toBe(Intl.DateTimeFormat().resolvedOptions().timeZone);
+    });
+
+    it('keeps existing timezone when disabled', () => {
+      useVisualizationStore.getState().setTimezone('Europe/London');
+      useVisualizationStore.getState().setTimezoneAutoDetect(false);
+      expect(useVisualizationStore.getState().timezone).toBe('Europe/London');
+    });
+  });
+});
+
+describe('formatTimestamp', () => {
+  const iso = '2025-03-15T14:30:45Z';
+
+  it('returns "--" for null or undefined', () => {
+    expect(formatTimestamp(null, 'UTC')).toBe('--');
+    expect(formatTimestamp(undefined, 'UTC')).toBe('--');
+  });
+
+  it('returns original string for invalid date', () => {
+    expect(formatTimestamp('not-a-date', 'UTC')).toBe('not-a-date');
+  });
+
+  it('formats with YYYY-MM-DD', () => {
+    const result = formatTimestamp(iso, 'UTC', 'YYYY-MM-DD', '24h');
+    expect(result).toMatch(/^2025-03-15,/);
+  });
+
+  it('formats with DD/MM/YYYY', () => {
+    const result = formatTimestamp(iso, 'UTC', 'DD/MM/YYYY', '24h');
+    expect(result).toMatch(/^15\/03\/2025,/);
+  });
+
+  it('formats with MM/DD/YYYY', () => {
+    const result = formatTimestamp(iso, 'UTC', 'MM/DD/YYYY', '24h');
+    expect(result).toMatch(/^03\/15\/2025,/);
+  });
+
+  it('formats with YYYY/MM/DD', () => {
+    const result = formatTimestamp(iso, 'UTC', 'YYYY/MM/DD', '24h');
+    expect(result).toMatch(/^2025\/03\/15,/);
+  });
+
+  it('formats with DD-MM-YYYY', () => {
+    const result = formatTimestamp(iso, 'UTC', 'DD-MM-YYYY', '24h');
+    expect(result).toMatch(/^15-03-2025,/);
+  });
+
+  it('formats with MM-DD-YYYY', () => {
+    const result = formatTimestamp(iso, 'UTC', 'MM-DD-YYYY', '24h');
+    expect(result).toMatch(/^03-15-2025,/);
+  });
+
+  it('accepts Date object', () => {
+    const result = formatTimestamp(new Date(iso), 'UTC', 'YYYY-MM-DD', '24h');
+    expect(result).toMatch(/^2025-03-15,/);
+  });
+
+  it('accepts numeric timestamp', () => {
+    const result = formatTimestamp(new Date(iso).getTime(), 'UTC', 'YYYY-MM-DD', '24h');
+    expect(result).toMatch(/^2025-03-15,/);
+  });
+
+  it('uses custom Intl options when provided', () => {
+    const result = formatTimestamp(iso, 'UTC', undefined, undefined, {
+      year: 'numeric',
+      month: 'short',
+    });
+    expect(result).toContain('2025');
+    expect(result).toContain('Mar');
+  });
+});


### PR DESCRIPTION
Add 12 new test files with 103 tests covering previously untested modules: authStore, visualizationStore, StatusBadge, DataTable, KpiCard, TopBar, Sidebar, Dashboard, Login, Alerts, AgentList, and AgentDetail. Raises overall statement coverage from 60.6% to 72.8% and test count from 38 to 141. Adds @vitest/coverage-v8 dev dependency.