### PR TITLE
Extend test coverage from 49% to 73% statements

### DIFF
--- a/src/api/__tests__/agents.test.ts
+++ b/src/api/__tests__/agents.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGet = vi.fn().mockResolvedValue({ data: {} });
+const mockPost = vi.fn().mockResolvedValue({ data: {} });
+
+vi.mock('../client', () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+  },
+}));
+
+import { agentsApi } from '../agents';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('agentsApi', () => {
+  it('list calls GET /agents with params', async () => {
+    await agentsApi.list({ page: 2, per_page: 25 });
+    expect(mockGet).toHaveBeenCalledWith('/agents', { params: { page: 2, per_page: 25 } });
+  });
+
+  it('get calls GET /agents/:id', async () => {
+    await agentsApi.get('abc-123');
+    expect(mockGet).toHaveBeenCalledWith('/agents/abc-123');
+  });
+
+  it('search calls GET /agents/search', async () => {
+    await agentsApi.search('host1');
+    expect(mockGet).toHaveBeenCalledWith('/agents/search', { params: { q: 'host1' } });
+  });
+
+  it('action calls POST /agents/:id/action', async () => {
+    await agentsApi.action('abc', 'reactivate');
+    expect(mockPost).toHaveBeenCalledWith('/agents/abc/action', { action: 'reactivate' });
+  });
+
+  it('bulkAction calls POST /agents/bulk-action', async () => {
+    await agentsApi.bulkAction(['a', 'b'], 'delete');
+    expect(mockPost).toHaveBeenCalledWith('/agents/bulk-action', { agent_ids: ['a', 'b'], action: 'delete' });
+  });
+
+  it('timeline calls GET /agents/:id/timeline', async () => {
+    await agentsApi.timeline('xyz');
+    expect(mockGet).toHaveBeenCalledWith('/agents/xyz/timeline');
+  });
+
+  it('imaLog calls GET with search param', async () => {
+    await agentsApi.imaLog('xyz', { search: 'test' });
+    expect(mockGet).toHaveBeenCalledWith('/agents/xyz/ima-log', { params: { search: 'test' } });
+  });
+
+  it('bootLog calls GET /agents/:id/boot-log', async () => {
+    await agentsApi.bootLog('xyz');
+    expect(mockGet).toHaveBeenCalledWith('/agents/xyz/boot-log');
+  });
+
+  it('certificates calls GET /agents/:id/certificates', async () => {
+    await agentsApi.certificates('xyz');
+    expect(mockGet).toHaveBeenCalledWith('/agents/xyz/certificates');
+  });
+
+  it('raw calls GET with source path when given', async () => {
+    await agentsApi.raw('xyz', 'verifier');
+    expect(mockGet).toHaveBeenCalledWith('/agents/xyz/raw/verifier');
+  });
+
+  it('raw calls GET without source path when omitted', async () => {
+    await agentsApi.raw('xyz');
+    expect(mockGet).toHaveBeenCalledWith('/agents/xyz/raw');
+  });
+});

--- a/src/api/__tests__/alerts.test.ts
+++ b/src/api/__tests__/alerts.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGet = vi.fn().mockResolvedValue({ data: {} });
+const mockPost = vi.fn().mockResolvedValue({ data: {} });
+
+vi.mock('../client', () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+  },
+}));
+
+import { alertsApi } from '../alerts';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('alertsApi', () => {
+  it('list calls GET /alerts with params', async () => {
+    await alertsApi.list({ severity: 'critical', page: 1 });
+    expect(mockGet).toHaveBeenCalledWith('/alerts', { params: { severity: 'critical', page: 1 } });
+  });
+
+  it('summary calls GET /alerts/summary', async () => {
+    await alertsApi.summary();
+    expect(mockGet).toHaveBeenCalledWith('/alerts/summary');
+  });
+
+  it('get calls GET /alerts/:id', async () => {
+    await alertsApi.get('alert-1');
+    expect(mockGet).toHaveBeenCalledWith('/alerts/alert-1');
+  });
+
+  it('acknowledge calls POST /alerts/:id/acknowledge', async () => {
+    await alertsApi.acknowledge('alert-1');
+    expect(mockPost).toHaveBeenCalledWith('/alerts/alert-1/acknowledge');
+  });
+
+  it('investigate calls POST with assignedTo', async () => {
+    await alertsApi.investigate('alert-1', 'admin');
+    expect(mockPost).toHaveBeenCalledWith('/alerts/alert-1/investigate', { assigned_to: 'admin' });
+  });
+
+  it('resolve calls POST with resolution', async () => {
+    await alertsApi.resolve('alert-1', 'fixed');
+    expect(mockPost).toHaveBeenCalledWith('/alerts/alert-1/resolve', { resolution: 'fixed' });
+  });
+
+  it('escalate calls POST /alerts/:id/escalate', async () => {
+    await alertsApi.escalate('alert-1');
+    expect(mockPost).toHaveBeenCalledWith('/alerts/alert-1/escalate');
+  });
+});

--- a/src/api/__tests__/attestations.test.ts
+++ b/src/api/__tests__/attestations.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGet = vi.fn().mockResolvedValue({ data: {} });
+const mockPost = vi.fn().mockResolvedValue({ data: {} });
+
+vi.mock('../client', () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+  },
+}));
+
+import { attestationsApi } from '../attestations';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('attestationsApi', () => {
+  it('summary calls GET with range param', async () => {
+    await attestationsApi.summary('24h');
+    expect(mockGet).toHaveBeenCalledWith('/attestations/summary', { params: { range: '24h' } });
+  });
+
+  it('timeline calls GET with range param', async () => {
+    await attestationsApi.timeline('7d');
+    expect(mockGet).toHaveBeenCalledWith('/attestations/timeline', { params: { range: '7d' } });
+  });
+
+  it('failures calls GET with range param', async () => {
+    await attestationsApi.failures('1h');
+    expect(mockGet).toHaveBeenCalledWith('/attestations/failures', { params: { range: '1h' } });
+  });
+
+  it('incidents calls GET with range param', async () => {
+    await attestationsApi.incidents('30d');
+    expect(mockGet).toHaveBeenCalledWith('/attestations/incidents', { params: { range: '30d' } });
+  });
+
+  it('rollbackPolicy calls POST with incident_id', async () => {
+    await attestationsApi.rollbackPolicy('inc-1');
+    expect(mockPost).toHaveBeenCalledWith('/attestations/rollback-policy', { incident_id: 'inc-1' });
+  });
+});

--- a/src/api/__tests__/audit.test.ts
+++ b/src/api/__tests__/audit.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGet = vi.fn().mockResolvedValue({ data: {} });
+const mockPost = vi.fn().mockResolvedValue({ data: {} });
+
+vi.mock('../client', () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+  },
+}));
+
+import { auditApi } from '../audit';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('auditApi', () => {
+  it('list calls GET /audit-log with params', async () => {
+    await auditApi.list({ severity: 'critical', page: 1 });
+    expect(mockGet).toHaveBeenCalledWith('/audit-log', { params: { severity: 'critical', page: 1 } });
+  });
+
+  it('export calls POST /audit-log/export', async () => {
+    await auditApi.export('csv', { from_date: '2025-01-01' });
+    expect(mockPost).toHaveBeenCalledWith(
+      '/audit-log/export',
+      { format: 'csv', from_date: '2025-01-01' },
+      { responseType: 'blob' },
+    );
+  });
+
+  it('verifyChain calls GET /audit-log/verify-chain', async () => {
+    await auditApi.verifyChain();
+    expect(mockGet).toHaveBeenCalledWith('/audit-log/verify-chain');
+  });
+});

--- a/src/api/__tests__/certificates.test.ts
+++ b/src/api/__tests__/certificates.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGet = vi.fn().mockResolvedValue({ data: {} });
+
+vi.mock('../client', () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+  },
+}));
+
+import { certificatesApi } from '../certificates';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('certificatesApi', () => {
+  it('list calls GET /certificates with params', async () => {
+    await certificatesApi.list({ type: 'ek' as never });
+    expect(mockGet).toHaveBeenCalledWith('/certificates', { params: { type: 'ek' } });
+  });
+
+  it('expirySummary calls GET /certificates/expiry-summary', async () => {
+    await certificatesApi.expirySummary();
+    expect(mockGet).toHaveBeenCalledWith('/certificates/expiry-summary');
+  });
+
+  it('get calls GET /certificates/:id', async () => {
+    await certificatesApi.get('cert-1');
+    expect(mockGet).toHaveBeenCalledWith('/certificates/cert-1');
+  });
+
+  it('timeline calls GET /certificates/timeline', async () => {
+    await certificatesApi.timeline();
+    expect(mockGet).toHaveBeenCalledWith('/certificates/timeline');
+  });
+
+  it('downloadPem calls GET with blob responseType', async () => {
+    await certificatesApi.downloadPem('cert-1');
+    expect(mockGet).toHaveBeenCalledWith('/certificates/cert-1/download/pem', { responseType: 'blob' });
+  });
+
+  it('downloadDer calls GET with blob responseType', async () => {
+    await certificatesApi.downloadDer('cert-1');
+    expect(mockGet).toHaveBeenCalledWith('/certificates/cert-1/download/der', { responseType: 'blob' });
+  });
+});

--- a/src/api/__tests__/client.test.ts
+++ b/src/api/__tests__/client.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getBackendUrl, setBackendUrl } from '../client';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('getBackendUrl', () => {
+  it('returns default when no saved URL', () => {
+    expect(getBackendUrl()).toBe('http://localhost:8080');
+  });
+
+  it('returns saved URL from localStorage', () => {
+    localStorage.setItem('backend-url', 'https://custom-backend:9090');
+    expect(getBackendUrl()).toBe('https://custom-backend:9090');
+  });
+
+  it('strips trailing slashes from saved URL', () => {
+    localStorage.setItem('backend-url', 'https://backend:8080///');
+    expect(getBackendUrl()).toBe('https://backend:8080');
+  });
+});
+
+describe('setBackendUrl', () => {
+  it('stores trimmed URL in localStorage', () => {
+    setBackendUrl('  https://example.com/  ');
+    expect(localStorage.getItem('backend-url')).toBe('https://example.com');
+  });
+
+  it('removes entry for empty string', () => {
+    localStorage.setItem('backend-url', 'https://old.url');
+    setBackendUrl('');
+    expect(localStorage.getItem('backend-url')).toBeNull();
+  });
+
+  it('removes entry for whitespace-only string', () => {
+    localStorage.setItem('backend-url', 'https://old.url');
+    setBackendUrl('   ');
+    expect(localStorage.getItem('backend-url')).toBeNull();
+  });
+});

--- a/src/api/__tests__/compliance.test.ts
+++ b/src/api/__tests__/compliance.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGet = vi.fn().mockResolvedValue({ data: {} });
+const mockPost = vi.fn().mockResolvedValue({ data: {} });
+
+vi.mock('../client', () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+  },
+}));
+
+import { complianceApi } from '../compliance';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('complianceApi', () => {
+  it('frameworks calls GET /compliance/frameworks', async () => {
+    await complianceApi.frameworks();
+    expect(mockGet).toHaveBeenCalledWith('/compliance/frameworks');
+  });
+
+  it('report calls GET /compliance/reports/:framework', async () => {
+    await complianceApi.report('nist');
+    expect(mockGet).toHaveBeenCalledWith('/compliance/reports/nist');
+  });
+
+  it('export calls POST with blob responseType', async () => {
+    await complianceApi.export('pci-dss', 'pdf');
+    expect(mockPost).toHaveBeenCalledWith(
+      '/compliance/export',
+      { framework: 'pci-dss', format: 'pdf' },
+      { responseType: 'blob' },
+    );
+  });
+});

--- a/src/api/__tests__/performance.test.ts
+++ b/src/api/__tests__/performance.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGet = vi.fn().mockResolvedValue({ data: {} });
+
+vi.mock('../client', () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+  },
+}));
+
+import { performanceApi } from '../performance';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('performanceApi', () => {
+  it('system calls GET /system/performance', async () => {
+    await performanceApi.system();
+    expect(mockGet).toHaveBeenCalledWith('/system/performance');
+  });
+
+  it('database calls GET /system/database', async () => {
+    await performanceApi.database();
+    expect(mockGet).toHaveBeenCalledWith('/system/database');
+  });
+
+  it('integrations calls GET /integrations/status', async () => {
+    await performanceApi.integrations();
+    expect(mockGet).toHaveBeenCalledWith('/integrations/status');
+  });
+
+  it('attestationBackends calls GET /integrations/attestation-backends', async () => {
+    await performanceApi.attestationBackends();
+    expect(mockGet).toHaveBeenCalledWith('/integrations/attestation-backends');
+  });
+});

--- a/src/api/__tests__/policies.test.ts
+++ b/src/api/__tests__/policies.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGet = vi.fn().mockResolvedValue({ data: {} });
+const mockPost = vi.fn().mockResolvedValue({ data: {} });
+const mockPut = vi.fn().mockResolvedValue({ data: {} });
+const mockDelete = vi.fn().mockResolvedValue({ data: {} });
+
+vi.mock('../client', () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+    put: (...args: unknown[]) => mockPut(...args),
+    delete: (...args: unknown[]) => mockDelete(...args),
+  },
+}));
+
+import { policiesApi } from '../policies';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('policiesApi', () => {
+  it('list calls GET /policies with params', async () => {
+    await policiesApi.list({ search: 'ima' });
+    expect(mockGet).toHaveBeenCalledWith('/policies', { params: { search: 'ima' } });
+  });
+
+  it('get calls GET /policies/:id', async () => {
+    await policiesApi.get('pol-1');
+    expect(mockGet).toHaveBeenCalledWith('/policies/pol-1');
+  });
+
+  it('create calls POST /policies', async () => {
+    await policiesApi.create({ name: 'new' });
+    expect(mockPost).toHaveBeenCalledWith('/policies', { name: 'new' });
+  });
+
+  it('update calls PUT /policies/:id', async () => {
+    await policiesApi.update('pol-1', { name: 'updated' });
+    expect(mockPut).toHaveBeenCalledWith('/policies/pol-1', { name: 'updated' });
+  });
+
+  it('delete calls DELETE /policies/:id', async () => {
+    await policiesApi.delete('pol-1');
+    expect(mockDelete).toHaveBeenCalledWith('/policies/pol-1');
+  });
+
+  it('versions calls GET /policies/:id/versions', async () => {
+    await policiesApi.versions('pol-1');
+    expect(mockGet).toHaveBeenCalledWith('/policies/pol-1/versions');
+  });
+
+  it('diff calls GET with from/to params', async () => {
+    await policiesApi.diff('pol-1', 1, 3);
+    expect(mockGet).toHaveBeenCalledWith('/policies/pol-1/diff', { params: { from: 1, to: 3 } });
+  });
+
+  it('rollback calls POST /policies/:id/rollback', async () => {
+    await policiesApi.rollback('pol-1', 2);
+    expect(mockPost).toHaveBeenCalledWith('/policies/pol-1/rollback', { version: 2 });
+  });
+
+  it('impactAnalysis calls POST /policies/impact-analysis', async () => {
+    await policiesApi.impactAnalysis('pol-1');
+    expect(mockPost).toHaveBeenCalledWith('/policies/impact-analysis', { policy_id: 'pol-1' });
+  });
+
+  it('submitForApproval calls POST', async () => {
+    await policiesApi.submitForApproval('pol-1');
+    expect(mockPost).toHaveBeenCalledWith('/policies/submit-for-approval', { policy_id: 'pol-1' });
+  });
+
+  it('approve calls POST /policies/:id/approve', async () => {
+    await policiesApi.approve('pol-1');
+    expect(mockPost).toHaveBeenCalledWith('/policies/pol-1/approve');
+  });
+
+  it('assignmentMatrix calls GET /policies/assignment-matrix', async () => {
+    await policiesApi.assignmentMatrix();
+    expect(mockGet).toHaveBeenCalledWith('/policies/assignment-matrix');
+  });
+});

--- a/src/api/__tests__/settings.test.ts
+++ b/src/api/__tests__/settings.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGet = vi.fn().mockResolvedValue({ data: {} });
+const mockPut = vi.fn().mockResolvedValue({ data: {} });
+
+vi.mock('../client', () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    put: (...args: unknown[]) => mockPut(...args),
+  },
+}));
+
+import { settingsApi } from '../settings';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('settingsApi', () => {
+  it('getKeylime calls GET /settings/keylime', async () => {
+    await settingsApi.getKeylime();
+    expect(mockGet).toHaveBeenCalledWith('/settings/keylime');
+  });
+
+  it('updateKeylime calls PUT /settings/keylime', async () => {
+    const settings = { verifier_url: 'https://v', registrar_url: 'https://r' };
+    await settingsApi.updateKeylime(settings);
+    expect(mockPut).toHaveBeenCalledWith('/settings/keylime', settings);
+  });
+
+  it('getCertificates calls GET /settings/certificates', async () => {
+    await settingsApi.getCertificates();
+    expect(mockGet).toHaveBeenCalledWith('/settings/certificates');
+  });
+
+  it('updateCertificates calls PUT /settings/certificates', async () => {
+    const settings = { cert_path: '/a', key_path: '/b', ca_cert_path: '/c' };
+    await settingsApi.updateCertificates(settings);
+    expect(mockPut).toHaveBeenCalledWith('/settings/certificates', settings);
+  });
+});

--- a/src/components/Layout/__tests__/Layout.test.tsx
+++ b/src/components/Layout/__tests__/Layout.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Layout } from '../Layout';
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: { name: 'Test', role: 'admin' },
+    isAuthenticated: true,
+    logout: vi.fn(),
+    canWrite: () => true,
+    isAdmin: () => true,
+    hasRole: () => true,
+  }),
+}));
+
+vi.mock('@/hooks/useWebSocket', () => ({
+  useWebSocket: () => ({ connected: false }),
+}));
+
+vi.mock('@/api/alerts', () => ({
+  alertsApi: { summary: vi.fn().mockResolvedValue({ data: {} }) },
+}));
+
+function renderLayout() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <Layout />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('Layout', () => {
+  it('renders sidebar and topbar', () => {
+    renderLayout();
+    expect(screen.getByRole('navigation')).toBeInTheDocument();
+  });
+
+  it('renders time range selector in top bar', () => {
+    renderLayout();
+    expect(screen.getByLabelText(/time range/i)).toBeInTheDocument();
+  });
+
+  it('renders sidebar toggle button', () => {
+    renderLayout();
+    const toggle = screen.getByLabelText(/toggle sidebar/i);
+    expect(toggle).toBeInTheDocument();
+  });
+
+  it('collapses sidebar on toggle click', () => {
+    renderLayout();
+    const toggle = screen.getByLabelText(/toggle sidebar/i);
+    fireEvent.click(toggle);
+    const layout = document.querySelector('.layout');
+    expect(layout?.classList.contains('layout--sidebar-collapsed')).toBe(true);
+  });
+
+  it('expands sidebar on second toggle click', () => {
+    renderLayout();
+    const toggle = screen.getByLabelText(/toggle sidebar/i);
+    fireEvent.click(toggle);
+    fireEvent.click(toggle);
+    const layout = document.querySelector('.layout');
+    expect(layout?.classList.contains('layout--sidebar-collapsed')).toBe(false);
+  });
+});

--- a/src/components/common/__tests__/AgentStateChart.test.tsx
+++ b/src/components/common/__tests__/AgentStateChart.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AgentStateChart } from '../AgentStateChart';
+
+vi.mock('@/api/agents', () => ({
+  agentsApi: {
+    list: vi.fn().mockResolvedValue({
+      data: {
+        items: [
+          { state: 'GET_QUOTE', attestation_mode: 'Pull' },
+          { state: 'PASS', attestation_mode: 'Push' },
+        ],
+      },
+    }),
+  },
+}));
+
+function renderChart() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <AgentStateChart />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('AgentStateChart', () => {
+  it('renders chart container when agents exist', async () => {
+    const { container } = renderChart();
+    await vi.waitFor(() => {
+      expect(container.querySelector('.recharts-responsive-container')).toBeInTheDocument();
+    });
+  });
+
+  it('shows no agents placeholder when empty', async () => {
+    const { agentsApi } = await import('@/api/agents');
+    vi.mocked(agentsApi.list).mockResolvedValueOnce({ data: { items: [] } } as never);
+    renderChart();
+    expect(await screen.findByText('No agents found')).toBeInTheDocument();
+  });
+
+  it('does not show placeholder when agents exist', async () => {
+    renderChart();
+    await vi.waitFor(() => {
+      expect(screen.queryByText('No agents found')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/hooks/__tests__/useAuth.test.ts
+++ b/src/hooks/__tests__/useAuth.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useAuth } from '../useAuth';
+
+beforeEach(() => {
+  sessionStorage.clear();
+});
+
+describe('useAuth', () => {
+  it('returns auth state and methods', () => {
+    const { result } = renderHook(() => useAuth());
+    expect(result.current).toHaveProperty('user');
+    expect(result.current).toHaveProperty('isAuthenticated');
+    expect(result.current).toHaveProperty('login');
+    expect(result.current).toHaveProperty('logout');
+    expect(result.current).toHaveProperty('hasRole');
+    expect(result.current).toHaveProperty('canWrite');
+    expect(result.current).toHaveProperty('isAdmin');
+  });
+
+  it('login sets user and isAuthenticated', () => {
+    const { result } = renderHook(() => useAuth());
+    act(() => {
+      result.current.login({ id: '1', email: 'a@b.com', name: 'Test', role: 'admin' }, 'test-token');
+    });
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.user?.role).toBe('admin');
+  });
+
+  it('logout clears user', () => {
+    const { result } = renderHook(() => useAuth());
+    act(() => {
+      result.current.login({ id: '1', email: 'a@b.com', name: 'Test', role: 'admin' }, 'test-token');
+    });
+    act(() => {
+      result.current.logout();
+    });
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.user).toBeNull();
+  });
+
+  it('canWrite returns true for operator and admin', () => {
+    const { result } = renderHook(() => useAuth());
+    act(() => {
+      result.current.login({ id: '1', email: 'a@b.com', name: 'Test', role: 'operator' }, 't');
+    });
+    expect(result.current.canWrite()).toBe(true);
+  });
+
+  it('canWrite returns false for viewer', () => {
+    const { result } = renderHook(() => useAuth());
+    act(() => {
+      result.current.login({ id: '1', email: 'a@b.com', name: 'Test', role: 'viewer' }, 't');
+    });
+    expect(result.current.canWrite()).toBe(false);
+  });
+
+  it('isAdmin returns true only for admin', () => {
+    const { result } = renderHook(() => useAuth());
+    act(() => {
+      result.current.login({ id: '1', email: 'a@b.com', name: 'Test', role: 'admin' }, 't');
+    });
+    expect(result.current.isAdmin()).toBe(true);
+  });
+
+  it('hasRole checks role hierarchy', () => {
+    const { result } = renderHook(() => useAuth());
+    act(() => {
+      result.current.login({ id: '1', email: 'a@b.com', name: 'Test', role: 'operator' }, 't');
+    });
+    expect(result.current.hasRole('viewer')).toBe(true);
+    expect(result.current.hasRole('operator')).toBe(true);
+    expect(result.current.hasRole('admin')).toBe(false);
+  });
+});

--- a/src/hooks/__tests__/useWebSocket.test.ts
+++ b/src/hooks/__tests__/useWebSocket.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useWebSocket } from '../useWebSocket';
+
+let wsInstances: MockWebSocket[] = [];
+
+class MockWebSocket {
+  url: string;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  closed = false;
+
+  constructor(url: string) {
+    this.url = url;
+    wsInstances.push(this);
+  }
+
+  close() {
+    this.closed = true;
+    this.onclose?.();
+  }
+
+  send() {}
+}
+
+beforeEach(() => {
+  wsInstances = [];
+  vi.useFakeTimers();
+  vi.stubGlobal('WebSocket', MockWebSocket);
+  sessionStorage.clear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('useWebSocket', () => {
+  it('creates a WebSocket connection', () => {
+    const onMessage = vi.fn();
+    renderHook(() => useWebSocket({ channel: 'test', onMessage }));
+    expect(wsInstances).toHaveLength(1);
+    expect(wsInstances[0].url).toContain('/test');
+  });
+
+  it('sets connected to true on open', () => {
+    const onMessage = vi.fn();
+    const { result } = renderHook(() => useWebSocket({ channel: 'test', onMessage }));
+    expect(result.current.connected).toBe(false);
+    act(() => wsInstances[0].onopen?.());
+    expect(result.current.connected).toBe(true);
+  });
+
+  it('passes parsed JSON messages to onMessage', () => {
+    const onMessage = vi.fn();
+    renderHook(() => useWebSocket({ channel: 'test', onMessage }));
+    act(() => wsInstances[0].onopen?.());
+    act(() => wsInstances[0].onmessage?.({ data: '{"type":"update"}' }));
+    expect(onMessage).toHaveBeenCalledWith({ type: 'update' });
+  });
+
+  it('passes raw data when JSON parsing fails', () => {
+    const onMessage = vi.fn();
+    renderHook(() => useWebSocket({ channel: 'test', onMessage }));
+    act(() => wsInstances[0].onopen?.());
+    act(() => wsInstances[0].onmessage?.({ data: 'raw-text' }));
+    expect(onMessage).toHaveBeenCalledWith('raw-text');
+  });
+
+  it('does not connect when disabled', () => {
+    const onMessage = vi.fn();
+    renderHook(() => useWebSocket({ channel: 'test', onMessage, enabled: false }));
+    expect(wsInstances).toHaveLength(0);
+  });
+
+  it('includes token in URL when available', () => {
+    sessionStorage.setItem('access_token', 'my-jwt');
+    const onMessage = vi.fn();
+    renderHook(() => useWebSocket({ channel: 'alerts', onMessage }));
+    expect(wsInstances[0].url).toContain('?token=my-jwt');
+  });
+
+  it('reconnects with exponential backoff on close', () => {
+    const onMessage = vi.fn();
+    renderHook(() => useWebSocket({ channel: 'test', onMessage }));
+    act(() => wsInstances[0].onopen?.());
+    act(() => {
+      wsInstances[0].onclose?.();
+    });
+    expect(wsInstances).toHaveLength(1);
+    act(() => { vi.advanceTimersByTime(1000); });
+    expect(wsInstances).toHaveLength(2);
+  });
+
+  it('closes WebSocket on error', () => {
+    const onMessage = vi.fn();
+    renderHook(() => useWebSocket({ channel: 'test', onMessage }));
+    act(() => wsInstances[0].onerror?.());
+    expect(wsInstances[0].closed).toBe(true);
+  });
+
+  it('cleans up on unmount', () => {
+    const onMessage = vi.fn();
+    const { unmount } = renderHook(() => useWebSocket({ channel: 'test', onMessage }));
+    unmount();
+    expect(wsInstances[0].closed).toBe(true);
+  });
+});

--- a/src/pages/Attestations/__tests__/Attestations.test.tsx
+++ b/src/pages/Attestations/__tests__/Attestations.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Route, Routes, Outlet } from 'react-router-dom';
+import { Attestations } from '../Attestations';
+
+vi.mock('@/api/attestations', () => ({
+  attestationsApi: {
+    summary: vi.fn().mockResolvedValue({
+      data: {
+        total_successful: 150,
+        total_failed: 5,
+        average_latency_ms: 42,
+        success_rate: 96.77,
+      },
+    }),
+    failures: vi.fn().mockResolvedValue({
+      data: [
+        {
+          agent_id: 'agent-001',
+          detail: 'PCR mismatch',
+          failure_type: 'pcr_validation',
+          severity: 'critical',
+          timestamp: '2025-01-01T00:00:00Z',
+        },
+      ],
+    }),
+  },
+}));
+
+function OutletWrapper() {
+  return <Outlet context={{ timeRange: '24h' }} />;
+}
+
+function renderAttestations() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/attestations']}>
+        <Routes>
+          <Route element={<OutletWrapper />}>
+            <Route path="/attestations" element={<Attestations />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('Attestations', () => {
+  it('renders page title and subtitle', () => {
+    renderAttestations();
+    expect(screen.getByText('Attestation Analytics')).toBeInTheDocument();
+    expect(screen.getByText(/Analyze attestation patterns/)).toBeInTheDocument();
+  });
+
+  it('renders KPI cards with summary data', async () => {
+    renderAttestations();
+    expect(await screen.findByText('150')).toBeInTheDocument();
+    expect(await screen.findByText('5')).toBeInTheDocument();
+    expect(await screen.findByText('42ms')).toBeInTheDocument();
+    expect(await screen.findByText('96.77%')).toBeInTheDocument();
+  });
+
+  it('renders failure categorization with failure events', async () => {
+    renderAttestations();
+    expect(await screen.findByText('pcr validation')).toBeInTheDocument();
+    expect(await screen.findByText('PCR mismatch')).toBeInTheDocument();
+    expect(await screen.findByText('agent-001')).toBeInTheDocument();
+  });
+
+  it('renders section headings', () => {
+    renderAttestations();
+    expect(screen.getByText('Failure Categorization')).toBeInTheDocument();
+    expect(screen.getByText('Hourly Volume')).toBeInTheDocument();
+    expect(screen.getByText('Correlated Incidents')).toBeInTheDocument();
+  });
+
+  it('renders 100.0% for perfect success rate', async () => {
+    const { attestationsApi } = await import('@/api/attestations');
+    vi.mocked(attestationsApi.summary).mockResolvedValueOnce({
+      data: {
+        total_successful: 100,
+        total_failed: 0,
+        average_latency_ms: 10,
+        success_rate: 100,
+      },
+    } as never);
+    renderAttestations();
+    expect(await screen.findByText('100.0%')).toBeInTheDocument();
+  });
+});

--- a/src/pages/AuditLog/__tests__/AuditLog.test.tsx
+++ b/src/pages/AuditLog/__tests__/AuditLog.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AuditLog } from '../AuditLog';
+
+vi.mock('@/api/audit', () => ({
+  auditApi: {
+    list: vi.fn().mockResolvedValue({
+      data: {
+        items: [
+          {
+            id: 'audit-1',
+            timestamp: '2025-01-15T10:00:00Z',
+            severity: 'info',
+            action: 'agent_registered',
+            actor: 'admin@example.com',
+            resource_type: 'agent',
+            result: 'success',
+            source_ip: '192.168.1.1',
+          },
+          {
+            id: 'audit-2',
+            timestamp: '2025-01-15T11:00:00Z',
+            severity: 'warning',
+            action: 'policy_modified',
+            actor: 'operator@example.com',
+            resource_type: 'policy',
+            result: 'success',
+            source_ip: '10.0.0.5',
+          },
+        ],
+      },
+    }),
+    verifyChain: vi.fn().mockResolvedValue({
+      data: {
+        verified: true,
+        total_entries: 42,
+        last_verification: '2025-01-15T12:00:00Z',
+      },
+    }),
+  },
+}));
+
+vi.mock('@/store/visualizationStore', () => ({
+  useFormatTimestamp: () => (ts: string | null) => ts ?? '--',
+}));
+
+function renderWithProviders(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('AuditLog', () => {
+  it('renders page title and subtitle', () => {
+    renderWithProviders(<AuditLog />);
+    expect(screen.getByText('Audit Log')).toBeInTheDocument();
+    expect(screen.getByText(/Tamper-evident security event log/)).toBeInTheDocument();
+  });
+
+  it('renders chain verification status', async () => {
+    renderWithProviders(<AuditLog />);
+    expect(await screen.findByText('Chain Verified')).toBeInTheDocument();
+    expect(await screen.findByText(/42 entries/)).toBeInTheDocument();
+  });
+
+  it('renders audit log entries in the table', async () => {
+    renderWithProviders(<AuditLog />);
+    expect(await screen.findByText('admin@example.com')).toBeInTheDocument();
+    expect(screen.getByText('operator@example.com')).toBeInTheDocument();
+    expect(screen.getByText('192.168.1.1')).toBeInTheDocument();
+  });
+
+  it('renders severity filter dropdown', () => {
+    renderWithProviders(<AuditLog />);
+    expect(screen.getByRole('combobox', { name: /filter by severity/i })).toBeInTheDocument();
+  });
+
+  it('changes severity filter', async () => {
+    const { auditApi } = await import('@/api/audit');
+    renderWithProviders(<AuditLog />);
+    const select = screen.getByRole('combobox', { name: /filter by severity/i });
+    fireEvent.change(select, { target: { value: 'critical' } });
+    expect(vi.mocked(auditApi.list)).toHaveBeenCalledWith({ severity: 'critical' });
+  });
+
+  it('renders export buttons', () => {
+    renderWithProviders(<AuditLog />);
+    expect(screen.getByText('Export CSV')).toBeInTheDocument();
+    expect(screen.getByText('Export JSON')).toBeInTheDocument();
+  });
+
+  it('renders broken chain status', async () => {
+    const { auditApi } = await import('@/api/audit');
+    vi.mocked(auditApi.verifyChain).mockResolvedValueOnce({
+      data: { verified: false, total_entries: 10, last_verification: null },
+    } as never);
+    renderWithProviders(<AuditLog />);
+    expect(await screen.findByText('Chain Broken')).toBeInTheDocument();
+  });
+});

--- a/src/pages/Performance/__tests__/Performance.test.tsx
+++ b/src/pages/Performance/__tests__/Performance.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Performance } from '../Performance';
+
+vi.mock('@/api/performance', () => ({
+  performanceApi: {
+    system: vi.fn().mockResolvedValue({
+      data: {
+        cpu_percent: 45.2,
+        memory_percent: 62.8,
+        attestations_per_sec: 120,
+        queue_depth: 15,
+      },
+    }),
+  },
+}));
+
+function renderWithProviders(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('Performance', () => {
+  it('renders page title and subtitle', () => {
+    renderWithProviders(<Performance />);
+    expect(screen.getByText('System Performance')).toBeInTheDocument();
+    expect(screen.getByText(/Monitor Keylime verifier cluster/)).toBeInTheDocument();
+  });
+
+  it('renders KPI cards with performance data', async () => {
+    renderWithProviders(<Performance />);
+    expect(await screen.findByText('45.2%')).toBeInTheDocument();
+    expect(await screen.findByText('62.8%')).toBeInTheDocument();
+    expect(await screen.findByText('120')).toBeInTheDocument();
+    expect(await screen.findByText('15')).toBeInTheDocument();
+  });
+
+  it('renders placeholder sections', () => {
+    renderWithProviders(<Performance />);
+    expect(screen.getByText('Verifier Cluster Metrics')).toBeInTheDocument();
+    expect(screen.getByText('Database Pool Status')).toBeInTheDocument();
+    expect(screen.getByText('Circuit Breaker Status')).toBeInTheDocument();
+  });
+
+  it('shows danger variant for high CPU usage', async () => {
+    const { performanceApi } = await import('@/api/performance');
+    vi.mocked(performanceApi.system).mockResolvedValueOnce({
+      data: {
+        cpu_percent: 92.5,
+        memory_percent: 30.0,
+        attestations_per_sec: 50,
+        queue_depth: 5,
+      },
+    } as never);
+    renderWithProviders(<Performance />);
+    expect(await screen.findByText('92.5%')).toBeInTheDocument();
+  });
+
+  it('shows warning variant for high queue depth', async () => {
+    const { performanceApi } = await import('@/api/performance');
+    vi.mocked(performanceApi.system).mockResolvedValueOnce({
+      data: {
+        cpu_percent: 10.0,
+        memory_percent: 20.0,
+        attestations_per_sec: 80,
+        queue_depth: 150,
+      },
+    } as never);
+    renderWithProviders(<Performance />);
+    expect(await screen.findByText('150')).toBeInTheDocument();
+  });
+
+  it('renders dashes when no data', async () => {
+    const { performanceApi } = await import('@/api/performance');
+    vi.mocked(performanceApi.system).mockResolvedValueOnce({ data: null } as never);
+    renderWithProviders(<Performance />);
+    const dashes = screen.getAllByText('--');
+    expect(dashes.length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/src/pages/Policies/__tests__/Policies.test.tsx
+++ b/src/pages/Policies/__tests__/Policies.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Policies } from '../Policies';
+
+vi.mock('@/api/policies', () => ({
+  policiesApi: {
+    list: vi.fn().mockResolvedValue({
+      data: {
+        items: [
+          {
+            id: 'pol-1',
+            name: 'IMA Default',
+            kind: 'ima',
+            checksum: 'abcdef1234567890abcdef',
+            approval_state: 'approved',
+            updated_date: '2025-01-10',
+          },
+          {
+            id: 'pol-2',
+            name: 'Boot Policy',
+            kind: 'measured_boot',
+            checksum: null,
+            approval_state: 'draft',
+            updated_date: '2025-01-12',
+          },
+        ],
+      },
+    }),
+  },
+}));
+
+let mockRole = 'operator';
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({
+    canWrite: () => mockRole === 'operator' || mockRole === 'admin',
+  }),
+}));
+
+function renderWithProviders(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockRole = 'operator';
+});
+
+describe('Policies', () => {
+  it('renders page title and subtitle', () => {
+    renderWithProviders(<Policies />);
+    expect(screen.getByText('Policies')).toBeInTheDocument();
+    expect(screen.getByText(/Manage IMA and Measured Boot/)).toBeInTheDocument();
+  });
+
+  it('renders policy list', async () => {
+    renderWithProviders(<Policies />);
+    expect(await screen.findByText('IMA Default')).toBeInTheDocument();
+    expect(screen.getByText('Boot Policy')).toBeInTheDocument();
+  });
+
+  it('renders kind labels correctly', async () => {
+    renderWithProviders(<Policies />);
+    expect(await screen.findByText('IMA')).toBeInTheDocument();
+    expect(screen.getByText('Measured Boot')).toBeInTheDocument();
+  });
+
+  it('renders truncated checksum', async () => {
+    renderWithProviders(<Policies />);
+    expect(await screen.findByText('abcdef123456...')).toBeInTheDocument();
+  });
+
+  it('shows New Policy and Import buttons for operators', async () => {
+    renderWithProviders(<Policies />);
+    await screen.findByText('IMA Default');
+    expect(screen.getByText('New Policy')).toBeInTheDocument();
+    expect(screen.getByText('Import')).toBeInTheDocument();
+  });
+
+  it('hides write buttons for viewers', async () => {
+    mockRole = 'viewer';
+    renderWithProviders(<Policies />);
+    await screen.findByText('IMA Default');
+    expect(screen.queryByText('New Policy')).not.toBeInTheDocument();
+    expect(screen.queryByText('Import')).not.toBeInTheDocument();
+  });
+
+  it('renders search input', () => {
+    renderWithProviders(<Policies />);
+    expect(screen.getByRole('searchbox', { name: /search policies/i })).toBeInTheDocument();
+  });
+
+  it('renders approval workflow steps', () => {
+    renderWithProviders(<Policies />);
+    expect(screen.getByText('Draft')).toBeInTheDocument();
+    expect(screen.getByText('Impact Analysis')).toBeInTheDocument();
+    expect(screen.getByText('Pending Approval')).toBeInTheDocument();
+    expect(screen.getByText('Approved')).toBeInTheDocument();
+    expect(screen.getByText('Applied')).toBeInTheDocument();
+  });
+
+  it('deduplicates policies with the same id', async () => {
+    const { policiesApi } = await import('@/api/policies');
+    vi.mocked(policiesApi.list).mockResolvedValueOnce({
+      data: {
+        items: [
+          { id: 'dup-1', name: 'DupPolicy', kind: 'ima', checksum: null, approval_state: 'draft', updated_date: '' },
+          { id: 'dup-1', name: 'DupPolicy', kind: 'ima', checksum: null, approval_state: 'draft', updated_date: '' },
+        ],
+      },
+    } as never);
+    renderWithProviders(<Policies />);
+    const items = await screen.findAllByText('DupPolicy');
+    expect(items).toHaveLength(1);
+  });
+});

--- a/src/pages/Settings/__tests__/Settings.test.tsx
+++ b/src/pages/Settings/__tests__/Settings.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Settings } from '../Settings';
+
+vi.mock('@/api/settings', () => ({
+  settingsApi: {
+    getKeylime: vi.fn().mockResolvedValue({
+      data: { verifier_url: 'https://localhost:8881', registrar_url: 'https://localhost:8891' },
+    }),
+    updateKeylime: vi.fn().mockResolvedValue({ data: {} }),
+    getCertificates: vi.fn().mockResolvedValue({
+      data: { cert_path: null, key_path: null, ca_cert_path: null },
+    }),
+    updateCertificates: vi.fn().mockResolvedValue({ data: {} }),
+  },
+}));
+
+vi.mock('@/api/client', () => ({
+  getBackendUrl: () => 'http://localhost:8080',
+  setBackendUrl: vi.fn(),
+}));
+
+let mockRole = 'admin';
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: { role: mockRole },
+    isAdmin: () => mockRole === 'admin',
+    canWrite: () => mockRole === 'operator' || mockRole === 'admin',
+  }),
+}));
+
+function renderWithProviders(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockRole = 'admin';
+  localStorage.clear();
+});
+
+describe('Settings', () => {
+  it('renders page title', () => {
+    renderWithProviders(<Settings />);
+    expect(screen.getByText('Settings')).toBeInTheDocument();
+  });
+
+  it('renders navigation sections', () => {
+    renderWithProviders(<Settings />);
+    expect(screen.getAllByText('Keylime Connection').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByRole('button', { name: 'Keylime Certificates' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Visualization' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Compliance Reports' })).toBeInTheDocument();
+  });
+
+  it('switches to Visualization section', () => {
+    renderWithProviders(<Settings />);
+    fireEvent.click(screen.getByRole('button', { name: 'Visualization' }));
+    expect(screen.getByLabelText('Theme')).toBeInTheDocument();
+    expect(screen.getByLabelText('Auto-refresh toggle')).toBeInTheDocument();
+  });
+
+  it('switches to Compliance section and shows frameworks', () => {
+    renderWithProviders(<Settings />);
+    fireEvent.click(screen.getByRole('button', { name: 'Compliance Reports' }));
+    expect(screen.getByText('NIST SP 800-155/193')).toBeInTheDocument();
+    expect(screen.getByText('PCI DSS 4.0')).toBeInTheDocument();
+    expect(screen.getByText('SOC 2 Type II')).toBeInTheDocument();
+  });
+
+  it('shows alert thresholds for admin', () => {
+    renderWithProviders(<Settings />);
+    fireEvent.click(screen.getByRole('button', { name: 'Alert Thresholds' }));
+    expect(screen.getByText('Alert threshold configuration')).toBeInTheDocument();
+  });
+
+  it('shows admin required message for non-admin on alert thresholds', () => {
+    mockRole = 'viewer';
+    renderWithProviders(<Settings />);
+    fireEvent.click(screen.getByRole('button', { name: 'Alert Thresholds' }));
+    expect(screen.getByText('Admin access required')).toBeInTheDocument();
+  });
+
+  it('renders Keylime Connection with URL inputs', () => {
+    renderWithProviders(<Settings />);
+    expect(screen.getByLabelText('Backend URL')).toBeInTheDocument();
+    expect(screen.getByLabelText('Verifier URL')).toBeInTheDocument();
+    expect(screen.getByLabelText('Registrar URL')).toBeInTheDocument();
+  });
+
+  it('renders mock/production mode toggle', () => {
+    renderWithProviders(<Settings />);
+    expect(screen.getByRole('button', { name: 'Mock' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Production' })).toBeInTheDocument();
+  });
+
+  it('switches to Certificates section', () => {
+    renderWithProviders(<Settings />);
+    fireEvent.click(screen.getByRole('button', { name: 'Keylime Certificates' }));
+    expect(screen.getByRole('button', { name: 'By directory' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Manually' })).toBeInTheDocument();
+  });
+
+  it('switches to manual certificate mode', () => {
+    renderWithProviders(<Settings />);
+    fireEvent.click(screen.getByRole('button', { name: 'Keylime Certificates' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Manually' }));
+    expect(screen.getByLabelText('CA certificate path')).toBeInTheDocument();
+    expect(screen.getByLabelText('Client certificate path')).toBeInTheDocument();
+    expect(screen.getByLabelText('Client key path')).toBeInTheDocument();
+  });
+
+  it('renders External Integrations section', () => {
+    renderWithProviders(<Settings />);
+    fireEvent.click(screen.getByRole('button', { name: 'External Integrations' }));
+    expect(screen.getByText('SIEM and ticketing integrations')).toBeInTheDocument();
+  });
+
+  it('renders General Settings section', () => {
+    renderWithProviders(<Settings />);
+    fireEvent.click(screen.getByRole('button', { name: 'General Settings' }));
+    expect(screen.getByText('Application preferences')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Add 124 new tests (141 -> 265 total) covering previously untested modules: API clients (agents, alerts, attestations, audit, certificates, compliance, performance, policies, settings), hooks (useAuth, useWebSocket), Layout component, AgentStateChart, and five page components (Attestations, AuditLog, Performance, Policies, Settings).