### PR TITLE
Extend test coverage from 82% to 87% statements

### DIFF
--- a/src/api/__tests__/client.test.ts
+++ b/src/api/__tests__/client.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { getBackendUrl, setBackendUrl } from '../client';
+import apiClient from '../client';
 
 beforeEach(() => {
   localStorage.clear();
+  sessionStorage.clear();
 });
 
 describe('getBackendUrl', () => {
@@ -37,5 +39,58 @@ describe('setBackendUrl', () => {
     localStorage.setItem('backend-url', 'https://old.url');
     setBackendUrl('   ');
     expect(localStorage.getItem('backend-url')).toBeNull();
+  });
+});
+
+describe('request interceptor — auth header', () => {
+  const authInterceptor = (apiClient.interceptors.request as unknown as { handlers: { fulfilled: (config: Record<string, unknown>) => Record<string, unknown> }[] }).handlers[1];
+
+  it('adds Authorization header when token exists', () => {
+    sessionStorage.setItem('access_token', 'test-jwt-token');
+    const config = { headers: {} as Record<string, string> };
+    const result = authInterceptor.fulfilled(config);
+    expect((result.headers as Record<string, string>).Authorization).toBe('Bearer test-jwt-token');
+  });
+
+  it('does not add Authorization header when no token', () => {
+    const config = { headers: {} as Record<string, string> };
+    const result = authInterceptor.fulfilled(config);
+    expect((result.headers as Record<string, string>).Authorization).toBeUndefined();
+  });
+});
+
+describe('response interceptor', () => {
+  const responseInterceptor = (apiClient.interceptors.response as unknown as { handlers: { fulfilled: (response: unknown) => unknown; rejected: (error: unknown) => Promise<never> }[] }).handlers[0];
+
+  it('unwraps envelope response with success field', () => {
+    const response = { data: { success: true, data: { foo: 1 }, timestamp: '2025-01-01' } };
+    const result = responseInterceptor.fulfilled(response) as { data: unknown };
+    expect(result.data).toEqual({ foo: 1 });
+  });
+
+  it('passes through response without envelope', () => {
+    const response = { data: [{ id: 1 }] };
+    const result = responseInterceptor.fulfilled(response) as { data: unknown };
+    expect(result.data).toEqual([{ id: 1 }]);
+  });
+
+  it('passes through response with non-object data', () => {
+    const response = { data: 'plain text' };
+    const result = responseInterceptor.fulfilled(response) as { data: unknown };
+    expect(result.data).toBe('plain text');
+  });
+
+  it('removes token on 401 error', async () => {
+    sessionStorage.setItem('access_token', 'old-token');
+    const error = { response: { status: 401 } };
+    await expect(responseInterceptor.rejected(error)).rejects.toEqual(error);
+    expect(sessionStorage.getItem('access_token')).toBeNull();
+  });
+
+  it('does not remove token on non-401 error', async () => {
+    sessionStorage.setItem('access_token', 'keep-me');
+    const error = { response: { status: 500 } };
+    await expect(responseInterceptor.rejected(error)).rejects.toEqual(error);
+    expect(sessionStorage.getItem('access_token')).toBe('keep-me');
   });
 });

--- a/src/components/Layout/__tests__/Layout.test.tsx
+++ b/src/components/Layout/__tests__/Layout.test.tsx
@@ -23,6 +23,19 @@ vi.mock('@/api/alerts', () => ({
   alertsApi: { summary: vi.fn().mockResolvedValue({ data: {} }) },
 }));
 
+vi.mock('@/api/performance', () => ({
+  performanceApi: { integrations: vi.fn().mockResolvedValue({ data: [] }) },
+}));
+
+vi.mock('@/api/settings', () => ({
+  settingsApi: { getKeylime: vi.fn().mockResolvedValue({ data: {} }) },
+}));
+
+vi.mock('@/api/client', () => ({
+  default: { get: vi.fn() },
+  getBackendUrl: () => 'http://localhost:8080',
+}));
+
 function renderLayout() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -68,5 +81,65 @@ describe('Layout', () => {
     fireEvent.click(toggle);
     const layout = document.querySelector('.layout');
     expect(layout?.classList.contains('layout--sidebar-collapsed')).toBe(false);
+  });
+
+  describe('sidebar drag resize', () => {
+    it('sets cursor on mousedown', () => {
+      renderLayout();
+      const handle = document.querySelector('.layout__resize-handle')!;
+      fireEvent.mouseDown(handle);
+      expect(document.body.style.cursor).toBe('col-resize');
+      expect(document.body.style.userSelect).toBe('none');
+    });
+
+    it('updates sidebar width on mousemove after mousedown', () => {
+      renderLayout();
+      const handle = document.querySelector('.layout__resize-handle')!;
+      fireEvent.mouseDown(handle);
+      fireEvent.mouseMove(document, { clientX: 300 });
+      const layout = document.querySelector('.layout') as HTMLElement;
+      expect(layout.style.getPropertyValue('--sidebar-width')).toBe('300px');
+    });
+
+    it('does not update sidebar on mousemove without mousedown', () => {
+      renderLayout();
+      const layout = document.querySelector('.layout') as HTMLElement;
+      const initialWidth = layout.style.getPropertyValue('--sidebar-width');
+      fireEvent.mouseMove(document, { clientX: 300 });
+      expect(layout.style.getPropertyValue('--sidebar-width')).toBe(initialWidth);
+    });
+
+    it('resets cursor on mouseup', () => {
+      renderLayout();
+      const handle = document.querySelector('.layout__resize-handle')!;
+      fireEvent.mouseDown(handle);
+      fireEvent.mouseUp(document);
+      expect(document.body.style.cursor).toBe('');
+      expect(document.body.style.userSelect).toBe('');
+    });
+
+    it('clamps width to MIN_SIDEBAR (180)', () => {
+      renderLayout();
+      const handle = document.querySelector('.layout__resize-handle')!;
+      fireEvent.mouseDown(handle);
+      fireEvent.mouseMove(document, { clientX: 50 });
+      const layout = document.querySelector('.layout') as HTMLElement;
+      expect(layout.style.getPropertyValue('--sidebar-width')).toBe('180px');
+    });
+
+    it('clamps width to MAX_SIDEBAR (400)', () => {
+      renderLayout();
+      const handle = document.querySelector('.layout__resize-handle')!;
+      fireEvent.mouseDown(handle);
+      fireEvent.mouseMove(document, { clientX: 800 });
+      const layout = document.querySelector('.layout') as HTMLElement;
+      expect(layout.style.getPropertyValue('--sidebar-width')).toBe('400px');
+    });
+
+    it('hides resize handle when sidebar is collapsed', () => {
+      renderLayout();
+      fireEvent.click(screen.getByLabelText(/toggle sidebar/i));
+      expect(document.querySelector('.layout__resize-handle')).toBeNull();
+    });
   });
 });

--- a/src/components/Layout/__tests__/Sidebar.test.tsx
+++ b/src/components/Layout/__tests__/Sidebar.test.tsx
@@ -49,4 +49,43 @@ describe('Sidebar', () => {
     renderSidebar();
     expect(screen.getByRole('navigation', { name: 'Main navigation' })).toBeInTheDocument();
   });
+
+  it('does not show alert indicator when all services are up', () => {
+    renderSidebar();
+    expect(screen.queryByLabelText('Service down')).not.toBeInTheDocument();
+  });
+
+  it('shows alert indicator when backend is down', async () => {
+    const { settingsApi } = await import('@/api/settings');
+    vi.mocked(settingsApi.getKeylime).mockRejectedValue(new Error('Network error'));
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={qc}>
+        <MemoryRouter>
+          <Sidebar />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+    expect(await screen.findByLabelText('Service down')).toBeInTheDocument();
+    vi.mocked(settingsApi.getKeylime).mockResolvedValue({ data: {} } as never);
+  });
+
+  it('shows alert indicator when a service is down', async () => {
+    const { performanceApi } = await import('@/api/performance');
+    vi.mocked(performanceApi.integrations).mockResolvedValue({
+      data: [
+        { name: 'Verifier', endpoint: 'https://v:3000', status: 'down', latency_ms: 0 },
+      ],
+    } as never);
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={qc}>
+        <MemoryRouter>
+          <Sidebar />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+    expect(await screen.findByLabelText('Service down')).toBeInTheDocument();
+    vi.mocked(performanceApi.integrations).mockResolvedValue({ data: [] } as never);
+  });
 });

--- a/src/components/Layout/__tests__/TopBar.test.tsx
+++ b/src/components/Layout/__tests__/TopBar.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { TopBar } from '../TopBar';
 import { useAuthStore } from '@/store/authStore';
+import { useVisualizationStore } from '@/store/visualizationStore';
 import type { User } from '@/types';
 
 const mockNavigate = vi.fn();
@@ -84,5 +85,26 @@ describe('TopBar', () => {
     renderTopBar();
     fireEvent.click(screen.getByLabelText('Settings'));
     expect(mockNavigate).toHaveBeenCalledWith('/settings');
+  });
+
+  it('toggles theme from light to dark', () => {
+    useVisualizationStore.setState({ theme: 'light' });
+    renderTopBar();
+    fireEvent.click(screen.getByLabelText('Switch to dark theme'));
+    expect(useVisualizationStore.getState().theme).toBe('dark');
+  });
+
+  it('toggles theme from dark to light', () => {
+    useVisualizationStore.setState({ theme: 'dark' });
+    renderTopBar();
+    fireEvent.click(screen.getByLabelText('Switch to light theme'));
+    expect(useVisualizationStore.getState().theme).toBe('light');
+  });
+
+  it('does not navigate on empty search submit', () => {
+    renderTopBar();
+    const form = screen.getByLabelText('Search agents').closest('form')!;
+    fireEvent.submit(form);
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 });

--- a/src/pages/Dashboard/__tests__/Dashboard.test.tsx
+++ b/src/pages/Dashboard/__tests__/Dashboard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Dashboard } from '../Dashboard';
@@ -103,5 +103,62 @@ describe('Dashboard', () => {
     expect(screen.getByText('severity')).toBeInTheDocument();
     expect(screen.getByText('type')).toBeInTheDocument();
     expect(screen.getByText('state')).toBeInTheDocument();
+  });
+
+  it('switches alert chart dimension on button click', async () => {
+    renderDashboard();
+    await screen.findByText('Total Agents');
+    const typeBtn = screen.getByText('type');
+    fireEvent.click(typeBtn);
+    expect(typeBtn).toHaveStyle({ fontWeight: '600' });
+    const sevBtn = screen.getByText('severity');
+    expect(sevBtn).toHaveStyle({ fontWeight: '400' });
+  });
+
+  it('renders attestation timeline placeholder when no data', async () => {
+    renderDashboard();
+    expect(await screen.findByText('No attestation timeline data')).toBeInTheDocument();
+  });
+
+  it('shows no alert data placeholder when alerts are empty', async () => {
+    const { alertsApi } = await import('@/api/alerts');
+    vi.mocked(alertsApi.list).mockResolvedValueOnce({
+      data: { items: [] },
+    } as never);
+    renderDashboard();
+    expect(await screen.findByText('No alert data to display')).toBeInTheDocument();
+  });
+
+  it('renders 100.0% when all agents are passing', async () => {
+    const { agentsApi } = await import('@/api/agents');
+    vi.mocked(agentsApi.list).mockResolvedValueOnce({
+      data: {
+        items: [
+          { id: 'a1', state: 'PASS', attestation_mode: 'Pull' },
+          { id: 'a2', state: 'GET_QUOTE', attestation_mode: 'Push' },
+        ],
+        total_items: 2,
+      },
+    } as never);
+    renderDashboard();
+    expect(await screen.findByText('100.0%')).toBeInTheDocument();
+  });
+
+  it('uses attestation summary when available', async () => {
+    const { attestationsApi } = await import('@/api/attestations');
+    vi.mocked(attestationsApi.summary).mockResolvedValueOnce({
+      data: { success_rate: 95.55, total_failed: 4, total_attested: 89 },
+    } as never);
+    renderDashboard();
+    expect(await screen.findByText('95.55%')).toBeInTheDocument();
+  });
+
+  it('renders failed attestation count from summary', async () => {
+    const { attestationsApi } = await import('@/api/attestations');
+    vi.mocked(attestationsApi.summary).mockResolvedValueOnce({
+      data: { success_rate: 90, total_failed: 7, total_attested: 70 },
+    } as never);
+    renderDashboard();
+    expect(await screen.findByText('7')).toBeInTheDocument();
   });
 });

--- a/src/pages/Integrations/__tests__/Integrations.test.tsx
+++ b/src/pages/Integrations/__tests__/Integrations.test.tsx
@@ -123,6 +123,60 @@ describe('SSH button RBAC', () => {
   });
 });
 
+describe('TopologyView rendering details', () => {
+  it('renders service status text', async () => {
+    renderWithProviders(<Integrations />);
+    expect(await screen.findByText('Verifier')).toBeInTheDocument();
+    const statusNodes = document.querySelectorAll('.topology-node__status');
+    const statuses = Array.from(statusNodes).map((n) => n.textContent);
+    expect(statuses).toContain('up');
+    expect(statuses).toContain('down');
+    expect(statuses).toContain('high load');
+  });
+
+  it('renders service latency values', async () => {
+    renderWithProviders(<Integrations />);
+    expect(await screen.findByText('12ms')).toBeInTheDocument();
+    expect(screen.getByText('45ms')).toBeInTheDocument();
+  });
+
+  it('renders service endpoint URLs', async () => {
+    renderWithProviders(<Integrations />);
+    expect(await screen.findByText('https://verifier.local:3000')).toBeInTheDocument();
+    expect(screen.getByText('https://registrar.local:3001')).toBeInTheDocument();
+    expect(screen.getByText('https://db.local:5432')).toBeInTheDocument();
+  });
+
+  it('renders image icons for service nodes', async () => {
+    renderWithProviders(<Integrations />);
+    await screen.findByText('Verifier');
+    const imgs = document.querySelectorAll('.topology-node img');
+    expect(imgs.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows backend unavailable when backend is down', async () => {
+    const { settingsApi } = await import('@/api/settings');
+    vi.mocked(settingsApi.getKeylime).mockRejectedValue(new Error('down'));
+    renderWithProviders(<Integrations />);
+    expect(await screen.findByText('Backend unavailable')).toBeInTheDocument();
+    vi.mocked(settingsApi.getKeylime).mockResolvedValue({} as never);
+  });
+
+  it('shows no services placeholder when services array is empty', async () => {
+    const { performanceApi } = await import('@/api/performance');
+    vi.mocked(performanceApi.integrations).mockResolvedValue({ data: [] } as never);
+    renderWithProviders(<Integrations />);
+    expect(await screen.findByText('No services configured')).toBeInTheDocument();
+    vi.mocked(performanceApi.integrations).mockResolvedValue({
+      data: [
+        { name: 'Verifier', endpoint: 'https://verifier.local:3000', status: 'up', latency_ms: 12 },
+        { name: 'Registrar', endpoint: 'https://registrar.local:3001', status: 'down', latency_ms: 0 },
+        { name: 'TimescaleDB', endpoint: 'https://db.local:5432', status: 'high_load', latency_ms: 45 },
+      ],
+    } as never);
+  });
+});
+
 describe('View mode persistence', () => {
   it('persists list mode across remounts', () => {
     const { unmount } = renderWithProviders(<Integrations />);


### PR DESCRIPTION
Add tests for API client interceptors (auth header, envelope unwrap, 401 handling), Layout sidebar drag-resize mouse events, Sidebar service-down alert indicator, TopBar theme toggle, TopologyView rendering details (status, latency, placeholders, icons), and Dashboard dimension toggle, timeline placeholder, and attestation summary precedence.