### PR TITLE
Drop deprecated baseUrl from tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,9 +16,8 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true,
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src"]


### PR DESCRIPTION
Remove baseUrl and use relative paths (./src/*) in the paths mapping, which works with moduleResolution "bundler" without baseUrl. This fixes the TS5101 deprecation warning ahead of TypeScript 7.0.