### PR TITLE
Separate timeout attestations from failures in KPI and charts

### DIFF
--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -24,6 +24,12 @@ export const ALERT_TYPE_COLORS: Record<string, string> = {
 
 export const ALERT_FALLBACK_COLOR = '#bdbdbd';
 
+export const ATTESTATION_COLORS = {
+  successful: '#34a853',
+  failed: '#ea4335',
+  timed_out: '#ff6d00',
+} as const;
+
 export const AGENT_STATE_COLORS: Record<string, string> = {
   GET_QUOTE: '#34a853',
   PROVIDE_V: '#4285f4',

--- a/src/pages/Attestations/Attestations.tsx
+++ b/src/pages/Attestations/Attestations.tsx
@@ -2,12 +2,13 @@ import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useOutletContext, Link } from 'react-router-dom';
 import {
-  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
+  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer,
 } from 'recharts';
 import { KpiCard } from '@/components/common/KpiCard';
 import { StatusBadge } from '@/components/common/StatusBadge';
 import { attestationsApi } from '@/api/attestations';
 import { useFormatTimestamp } from '@/store/visualizationStore';
+import { ATTESTATION_COLORS } from '@/constants/colors';
 
 interface FailureEvent {
   agent_id: string;
@@ -68,6 +69,11 @@ export function Attestations() {
           variant="danger"
         />
         <KpiCard
+          title="Timed Out"
+          value={summary?.total_timed_out ?? '--'}
+          variant="warning"
+        />
+        <KpiCard
           title="Avg Latency"
           value={summary?.average_latency_ms != null ? `${summary.average_latency_ms}ms` : '--'}
         />
@@ -118,8 +124,10 @@ export function Attestations() {
                     color: 'var(--color-text)',
                   }}
                 />
-                <Bar dataKey="successful" name="Successful" fill="#34a853" stackId="a" />
-                <Bar dataKey="failed" name="Failed" fill="#ea4335" stackId="a" />
+                <Bar dataKey="successful" name="Successful" fill={ATTESTATION_COLORS.successful} stackId="a" />
+                <Bar dataKey="failed" name="Failed" fill={ATTESTATION_COLORS.failed} stackId="a" />
+                <Bar dataKey="timed_out" name="Timed Out" fill={ATTESTATION_COLORS.timed_out} stackId="a" />
+                <Legend />
               </BarChart>
             </ResponsiveContainer>
           ) : (

--- a/src/pages/Attestations/__tests__/Attestations.test.tsx
+++ b/src/pages/Attestations/__tests__/Attestations.test.tsx
@@ -10,8 +10,9 @@ vi.mock('@/api/attestations', () => ({
       data: {
         total_successful: 150,
         total_failed: 5,
+        total_timed_out: 3,
         average_latency_ms: 42,
-        success_rate: 96.77,
+        success_rate: 94.94,
       },
     }),
     failures: vi.fn().mockResolvedValue({
@@ -23,6 +24,12 @@ vi.mock('@/api/attestations', () => ({
           severity: 'critical',
           timestamp: '2025-01-01T00:00:00Z',
         },
+      ],
+    }),
+    timeline: vi.fn().mockResolvedValue({
+      data: [
+        { hour: '2025-01-01T00:00:00Z', successful: 10, failed: 2, timed_out: 1 },
+        { hour: '2025-01-01T01:00:00Z', successful: 12, failed: 1, timed_out: 0 },
       ],
     }),
   },
@@ -61,8 +68,9 @@ describe('Attestations', () => {
     renderAttestations();
     expect(await screen.findByText('150')).toBeInTheDocument();
     expect(await screen.findByText('5')).toBeInTheDocument();
+    expect(await screen.findByText('3')).toBeInTheDocument();
     expect(await screen.findByText('42ms')).toBeInTheDocument();
-    expect(await screen.findByText('96.77%')).toBeInTheDocument();
+    expect(await screen.findByText('94.94%')).toBeInTheDocument();
   });
 
   it('renders failure categorization with failure events', async () => {
@@ -85,11 +93,22 @@ describe('Attestations', () => {
       data: {
         total_successful: 100,
         total_failed: 0,
+        total_timed_out: 0,
         average_latency_ms: 10,
         success_rate: 100,
       },
     } as never);
     renderAttestations();
     expect(await screen.findByText('100.0%')).toBeInTheDocument();
+  });
+
+  it('renders Timed Out KPI card', async () => {
+    renderAttestations();
+    expect(await screen.findByText('Timed Out')).toBeInTheDocument();
+  });
+
+  it('renders hourly volume section heading', () => {
+    renderAttestations();
+    expect(screen.getByText('Hourly Volume')).toBeInTheDocument();
   });
 });

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -14,6 +14,7 @@ import { useFormatTimestamp } from '@/store/visualizationStore';
 import type { Alert } from '@/types';
 import {
   ALERT_SEVERITY_COLORS, ALERT_TYPE_COLORS, ALERT_STATE_COLORS, ALERT_FALLBACK_COLOR,
+  ATTESTATION_COLORS,
 } from '@/constants/colors';
 import { createPieLabelRenderer } from '@/utils/pieLabel';
 
@@ -27,8 +28,9 @@ const ALERT_COLOR_MAPS: Record<AlertChartDimension, Record<string, string>> = {
 
 // Agent states used to derive attestation stats as a fallback
 const FAILED_STATES = new Set([
-  'FAILED', 'INVALID_QUOTE', 'TENANT_FAILED', 'FAIL', 'TIMEOUT',
+  'FAILED', 'INVALID_QUOTE', 'TENANT_FAILED', 'FAIL',
 ]);
+const TIMEOUT_STATES = new Set(['TIMEOUT']);
 const ATTESTED_STATES = new Set([
   'GET_QUOTE', 'PROVIDE_V', 'REGISTERED', 'PASS',
   'FAILED', 'INVALID_QUOTE', 'TENANT_FAILED', 'FAIL', 'TIMEOUT',
@@ -86,14 +88,13 @@ export function Dashboard() {
     [agents]
   );
 
-  // Derive attestation stats from agent states when the summary endpoint
-  // returns no data (e.g. backend attestation history not yet available).
   const agentAttestation = useMemo(() => {
     const attested = agentItems.filter((a) => ATTESTED_STATES.has((a.state ?? '').toUpperCase()));
     if (attested.length === 0) return null;
     const failedCount = attested.filter((a) => FAILED_STATES.has((a.state ?? '').toUpperCase())).length;
-    const successRate = ((attested.length - failedCount) / attested.length) * 100;
-    return { successRate, failedCount };
+    const timedOutCount = attested.filter((a) => TIMEOUT_STATES.has((a.state ?? '').toUpperCase())).length;
+    const successRate = ((attested.length - failedCount - timedOutCount) / attested.length) * 100;
+    return { successRate, failedCount, timedOutCount };
   }, [agentItems]);
 
   const alertItems: Alert[] = useMemo(
@@ -143,7 +144,14 @@ export function Dashboard() {
           value={attestationSummary?.total_failed ?? agentAttestation?.failedCount ?? '--'}
           variant="danger"
           subtitle={`in last ${timeRange}`}
-          linkTo="/agents?state=FAILED,INVALID_QUOTE,TENANT_FAILED,FAIL,TIMEOUT"
+          linkTo="/agents?state=FAILED,INVALID_QUOTE,TENANT_FAILED,FAIL"
+        />
+        <KpiCard
+          title="Timed-Out Attestations"
+          value={attestationSummary?.total_timed_out ?? agentAttestation?.timedOutCount ?? '--'}
+          variant="warning"
+          subtitle={`in last ${timeRange}`}
+          linkTo="/agents?state=TIMEOUT"
         />
         <KpiCard
           title="Urgent Alerts"
@@ -252,8 +260,10 @@ export function Dashboard() {
                   color: 'var(--color-text)',
                 }}
               />
-              <Bar dataKey="successful" name="Successful" fill="#34a853" stackId="a" />
-              <Bar dataKey="failed" name="Failed" fill="#ea4335" stackId="a" />
+              <Bar dataKey="successful" name="Successful" fill={ATTESTATION_COLORS.successful} stackId="a" />
+              <Bar dataKey="failed" name="Failed" fill={ATTESTATION_COLORS.failed} stackId="a" />
+              <Bar dataKey="timed_out" name="Timed Out" fill={ATTESTATION_COLORS.timed_out} stackId="a" />
+              <Legend />
             </BarChart>
           </ResponsiveContainer>
         ) : (

--- a/src/pages/Dashboard/__tests__/Dashboard.test.tsx
+++ b/src/pages/Dashboard/__tests__/Dashboard.test.tsx
@@ -21,8 +21,9 @@ vi.mock('@/api/agents', () => ({
           { id: 'a1', state: 'GET_QUOTE', attestation_mode: 'Pull' },
           { id: 'a2', state: 'FAILED', attestation_mode: 'Pull' },
           { id: 'a3', state: 'PASS', attestation_mode: 'Push' },
+          { id: 'a4', state: 'TIMEOUT', attestation_mode: 'Push' },
         ],
-        total_items: 3,
+        total_items: 4,
       },
     }),
   },
@@ -83,13 +84,13 @@ describe('Dashboard', () => {
 
   it('uses fallback agent attestation stats when summary is null', async () => {
     renderDashboard();
-    // 2 of 3 agents are attested (GET_QUOTE, FAILED, PASS); 1 failed → 66.67%
-    expect(await screen.findByText('66.67%')).toBeInTheDocument();
+    // 4 attested agents (GET_QUOTE, FAILED, PASS, TIMEOUT); 1 failed + 1 timed out → 50%
+    expect(await screen.findByText('50.00%')).toBeInTheDocument();
   });
 
   it('renders total agents from API', async () => {
     renderDashboard();
-    expect(await screen.findByText('3')).toBeInTheDocument();
+    expect(await screen.findByText('4')).toBeInTheDocument();
   });
 
   it('renders alert summary subtitle', async () => {
@@ -156,9 +157,48 @@ describe('Dashboard', () => {
   it('renders failed attestation count from summary', async () => {
     const { attestationsApi } = await import('@/api/attestations');
     vi.mocked(attestationsApi.summary).mockResolvedValueOnce({
-      data: { success_rate: 90, total_failed: 7, total_attested: 70 },
+      data: { success_rate: 90, total_failed: 7, total_timed_out: 3, total_attested: 70 },
     } as never);
     renderDashboard();
     expect(await screen.findByText('7')).toBeInTheDocument();
+  });
+
+  it('renders timed-out attestations KPI card', async () => {
+    renderDashboard();
+    expect(await screen.findByText('Timed-Out Attestations')).toBeInTheDocument();
+  });
+
+  it('renders timed-out count from fallback agent states', async () => {
+    renderDashboard();
+    const timedOutCard = await screen.findByText('Timed-Out Attestations');
+    expect(timedOutCard).toBeInTheDocument();
+  });
+
+  it('renders timed-out count from summary when available', async () => {
+    const { attestationsApi } = await import('@/api/attestations');
+    vi.mocked(attestationsApi.summary).mockResolvedValueOnce({
+      data: { success_rate: 85, total_failed: 10, total_timed_out: 8, total_attested: 100 },
+    } as never);
+    renderDashboard();
+    expect(await screen.findByText('8')).toBeInTheDocument();
+  });
+
+  it('computes three-way success rate excluding both failed and timed-out', async () => {
+    const { agentsApi } = await import('@/api/agents');
+    vi.mocked(agentsApi.list).mockResolvedValueOnce({
+      data: {
+        items: [
+          { id: 'a1', state: 'PASS', attestation_mode: 'Push' },
+          { id: 'a2', state: 'PASS', attestation_mode: 'Push' },
+          { id: 'a3', state: 'FAIL', attestation_mode: 'Push' },
+          { id: 'a4', state: 'TIMEOUT', attestation_mode: 'Push' },
+          { id: 'a5', state: 'TIMEOUT', attestation_mode: 'Push' },
+        ],
+        total_items: 5,
+      },
+    } as never);
+    renderDashboard();
+    // 5 attested, 1 fail + 2 timeout → success = 2/5 = 40%
+    expect(await screen.findByText('40.00%')).toBeInTheDocument();
   });
 });

--- a/src/types/attestation.ts
+++ b/src/types/attestation.ts
@@ -29,6 +29,7 @@ export interface Attestation {
 export interface AttestationSummary {
   total_successful: number;
   total_failed: number;
+  total_timed_out: number;
   average_latency_ms: number;
   success_rate: number;
 }
@@ -37,6 +38,7 @@ export interface AttestationTimelinePoint {
   hour: string;
   successful: number;
   failed: number;
+  timed_out: number;
 }
 
 export interface FailureCategoryCount {


### PR DESCRIPTION
Push-mode state 103 (Timeout) was lumped with Fail (state 101) in the success rate computation, KPI cards, and bar charts. Per FR-001, FR-024, and SDD 3.7.2, timeout is a distinct outcome that operators need to triage separately from hard failures — confusing the two masks intermittent network issues behind real attestation errors.

The success rate formula now excludes both failed and timed-out counts: ((total - failed - timed_out) / total) * 100. The orange color (#ff6d00) already used for TIMEOUT in the agent state pie chart is reused via a shared ATTESTATION_COLORS constant.