### PR TITLE
Fix pie chart legend color mismatch with slice colors

### DIFF
--- a/src/components/common/AgentStateChart.tsx
+++ b/src/components/common/AgentStateChart.tsx
@@ -133,8 +133,8 @@ export function AgentStateChart() {
                 display: 'flex', flexWrap: 'wrap', justifyContent: 'center',
                 listStyle: 'none', padding: 0, margin: '8px 0 0', gap: '8px 16px',
               }}>
-                {payload.map((item, index) => {
-                  const entry = stateDistribution[index];
+                {payload.map((item) => {
+                  const entry = item.payload as StateEntry;
                   if (!entry) return null;
                   const isPull = PULL_STATES.has(entry.state);
                   const color = AGENT_STATE_COLORS[entry.state] ?? AGENT_STATE_COLORS.UNKNOWN;


### PR DESCRIPTION
The custom legend used stateDistribution[index] to resolve each entry's color, but Recharts may reorder legend payload items (e.g. alphabetically), causing the swatch color to map to the wrong state. Extracting the entry from item.payload instead ties each legend swatch to its actual data point regardless of order.