### PR TITLE
Fix pie chart data disappearing on auto-refresh

### DIFF
--- a/src/components/common/AgentStateChart.tsx
+++ b/src/components/common/AgentStateChart.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
 import { PieChart, Pie, Cell, Legend, ResponsiveContainer } from 'recharts';
 import { agentsApi } from '@/api/agents';
 import { AGENT_STATE_COLORS } from '@/constants/colors';
@@ -25,6 +25,7 @@ export function AgentStateChart() {
     queryKey: ['agents', 'dashboard'],
     queryFn: () => agentsApi.list({ per_page: 100 }),
     select: (res) => res.data,
+    placeholderData: keepPreviousData,
   });
 
   const agentItems = useMemo(
@@ -90,6 +91,7 @@ export function AgentStateChart() {
           innerRadius={50}
           dataKey="value"
           nameKey="name"
+          isAnimationActive={false}
           label={createPieLabelRenderer({
             colors: AGENT_STATE_COLORS,
             offset: 20,

--- a/src/pages/Alerts/Alerts.tsx
+++ b/src/pages/Alerts/Alerts.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
 import {
   PieChart, Pie, Cell, Legend, ResponsiveContainer,
 } from 'recharts';
@@ -62,6 +62,7 @@ function AlertPieChart({
             innerRadius={40}
             dataKey="value"
             nameKey="name"
+            isAnimationActive={false}
             label={createPieLabelRenderer({
               colors,
               fallbackColor: ALERT_FALLBACK_COLOR,
@@ -106,6 +107,7 @@ export function Alerts() {
     queryKey: ['alerts', 'summary'],
     queryFn: () => alertsApi.summary(),
     select: (res) => res.data,
+    placeholderData: keepPreviousData,
   });
 
   const { data: alerts, isLoading } = useQuery({
@@ -117,6 +119,7 @@ export function Alerts() {
         type: typeFilter || undefined,
       }),
     select: (res) => res.data,
+    placeholderData: keepPreviousData,
   });
 
   const alertItems = useMemo(

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
 import {
   PieChart, Pie, Cell, Legend, ResponsiveContainer,
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip,
@@ -45,18 +45,21 @@ export function Dashboard() {
     queryKey: ['agents', 'dashboard'],
     queryFn: () => agentsApi.list({ per_page: 100 }),
     select: (res) => res.data,
+    placeholderData: keepPreviousData,
   });
 
   const { data: attestationSummary } = useQuery({
     queryKey: ['attestations', 'summary', timeRange],
     queryFn: () => attestationsApi.summary(timeRange),
     select: (res) => res.data,
+    placeholderData: keepPreviousData,
   });
 
   const { data: attestationTimeline } = useQuery({
     queryKey: ['attestations', 'timeline', timeRange],
     queryFn: () => attestationsApi.timeline(timeRange),
     select: (res) => res.data,
+    placeholderData: keepPreviousData,
   });
 
   const timelineData = useMemo(() => {
@@ -73,12 +76,14 @@ export function Dashboard() {
     queryKey: ['alerts', 'summary'],
     queryFn: () => alertsApi.summary(),
     select: (res) => res.data,
+    placeholderData: keepPreviousData,
   });
 
   const { data: alertsData } = useQuery({
     queryKey: ['alerts', 'dashboard'],
     queryFn: () => alertsApi.list({ per_page: 100 }),
     select: (res) => res.data,
+    placeholderData: keepPreviousData,
   });
 
   const [alertChartDimension, setAlertChartDimension] = useState<AlertChartDimension>('severity');
@@ -204,6 +209,7 @@ export function Dashboard() {
                 innerRadius={45}
                 dataKey="value"
                 nameKey="name"
+                isAnimationActive={false}
                 label={createPieLabelRenderer({
                   colors: ALERT_COLOR_MAPS[alertChartDimension],
                   fallbackColor: ALERT_FALLBACK_COLOR,


### PR DESCRIPTION
Disable Recharts animation on Pie components and add keepPreviousData to queries so charts no longer flicker when data refetches.