### PR TITLE
Send seed_mock_data flag when applying settings

### DIFF
--- a/src/api/settings.ts
+++ b/src/api/settings.ts
@@ -3,6 +3,7 @@ import apiClient from './client';
 export interface KeylimeSettings {
   verifier_url: string;
   registrar_url: string;
+  seed_mock_data?: boolean;
 }
 
 export interface CertificateSettings {

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -179,7 +179,7 @@ export function Settings() {
     // Save Verifier + Registrar to backend API, then reload
     if (verifierUrlChanged || registrarUrlChanged) {
       updateMutation.mutate(
-        { verifier_url: verifierUrl.trim(), registrar_url: registrarUrl.trim() },
+        { verifier_url: verifierUrl.trim(), registrar_url: registrarUrl.trim(), seed_mock_data: envMode === 'mock' },
         { onSuccess: () => window.location.reload() },
       );
     } else {

--- a/src/pages/Settings/__tests__/Settings.test.tsx
+++ b/src/pages/Settings/__tests__/Settings.test.tsx
@@ -204,6 +204,49 @@ describe('Settings', () => {
       const applyBtn = screen.getByText('Apply Changes');
       expect(applyBtn).not.toBeDisabled();
     });
+
+    it('sends seed_mock_data true when applying in mock mode', async () => {
+      const { settingsApi } = await import('@/api/settings');
+      renderWithProviders(<Settings />);
+      await waitFor(() => {
+        expect((screen.getByLabelText('Verifier URL') as HTMLInputElement).value).toBe('https://localhost:8881');
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Mock' }));
+      await waitFor(() => {
+        expect((screen.getByLabelText('Verifier URL') as HTMLInputElement).value).toBe('http://localhost:3000');
+      });
+      fireEvent.click(screen.getByText('Apply Changes'));
+      await waitFor(() => {
+        expect(settingsApi.updateKeylime).toHaveBeenCalledWith(
+          expect.objectContaining({ seed_mock_data: true }),
+        );
+      });
+    });
+
+    it('sends seed_mock_data false when applying in production mode', async () => {
+      const { settingsApi } = await import('@/api/settings');
+      renderWithProviders(<Settings />);
+      await waitFor(() => {
+        expect((screen.getByLabelText('Verifier URL') as HTMLInputElement).value).toBe('https://localhost:8881');
+      });
+      // Switch to mock then back to production to create a diff from saved values
+      fireEvent.click(screen.getByRole('button', { name: 'Mock' }));
+      await waitFor(() => {
+        expect((screen.getByLabelText('Verifier URL') as HTMLInputElement).value).toBe('http://localhost:3000');
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Production' }));
+      await waitFor(() => {
+        expect((screen.getByLabelText('Verifier URL') as HTMLInputElement).value).toBe('https://localhost:8881');
+      });
+      // Manually change a URL so Apply is enabled (production URLs match saved, so no diff otherwise)
+      fireEvent.change(screen.getByLabelText('Verifier URL'), { target: { value: 'https://verifier.example.com:8881' } });
+      fireEvent.click(screen.getByText('Apply Changes'));
+      await waitFor(() => {
+        expect(settingsApi.updateKeylime).toHaveBeenCalledWith(
+          expect.objectContaining({ seed_mock_data: false }),
+        );
+      });
+    });
   });
 
   describe('Certificates section', () => {


### PR DESCRIPTION
Derive seed_mock_data from the selected environment mode (true for Mock, false for Production) and include it in the PUT /api/settings/keylime payload so the backend can gate SQLite alert seeding on this flag.

Requires a matching backend change: accept seed_mock_data in the KeylimeSettings handler and propagate it to PersistedSettings.