### PR TITLE
Bump CI Node.js from 22 to 24 (Active LTS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npx tsc -b
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npm run lint
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npx vitest --run --coverage
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/setup-node@v6
         if: steps.changes.outputs.deps == 'true'
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - name: Install dependencies
         if: steps.changes.outputs.deps == 'true'


### PR DESCRIPTION
Node.js 24 is now the Active LTS release. This bumps all CI workflow jobs from Node 22 (Maintenance LTS) to Node 24.