### PR TITLE
Fix timeout agent state badge from danger to warning (FR-012)

### DIFF
--- a/src/components/common/StatusBadge.tsx
+++ b/src/components/common/StatusBadge.tsx
@@ -28,7 +28,7 @@ const VARIANT_MAP: Record<string, BadgeVariant> = {
   info: 'info',
   // Push-mode agent states
   pending: 'warning',
-  timeout: 'danger',
+  timeout: 'warning',
   // Certificate expiry categories
   warning_90d: 'info',
   warning_30d: 'warning',


### PR DESCRIPTION
Align the agent fleet list timeout indicator with FR-001 KPI dashboard by mapping timeout to the warning (orange) variant instead of danger (red), distinguishing it from actual failure states.